### PR TITLE
Audit server tls support

### DIFF
--- a/configure
+++ b/configure
@@ -744,6 +744,7 @@ LOCALEDIR_SUFFIX
 SUDO_NLS
 LIBPTHREAD
 LIBMD
+OPENSSL_LIBS
 LIBINTL
 LIBRT
 LIBDL
@@ -3152,6 +3153,7 @@ PSMAN=0
 SEMAN=0
 LIBINTL=
 LIBMD=
+OPENSSL_LIBS=
 ZLIB=
 ZLIB_SRC=
 AUTH_OBJS=
@@ -6428,6 +6430,7 @@ if test "${enable_openssl+set}" = set; then :
   enableval=$enable_openssl;  case $enableval in
     no)		;;
     *)		LIBMD="-lcrypto"
+        OPENSSL_LIBS="-lcrypto -lssl"
 		DIGEST=digest_openssl.lo
 		$as_echo "#define HAVE_OPENSSL 1" >>confdefs.h
 

--- a/examples/sudo_logsrvd.conf
+++ b/examples/sudo_logsrvd.conf
@@ -16,6 +16,47 @@
 # Multiple listen_address settings may be specified.
 # The default is to listen on all addresses.
 #listen_address = *:30344
+#
+# Sets audit server's communication over TLS on/off.
+# Minimum negotiable TLS version is 1.2
+#tls = true
+
+# Path to the certificate authority bundle file
+# It must be in PEM format!
+#tls_cacert = /etc/sudo_logsrvd_ca.pem
+
+# Path to the audit server's private key file
+# It must be in PEM format!
+#tls_key = /etc/sudo_logsrvd_key.pem
+
+# Path to the audit server's certificate file
+# It must be in PEM format!
+#tls_cert = /etc/sudo_logsrvd_cert.pem
+
+# Path to the Diffie-Hellman parameter file
+# If this parameter is not set, the audit server
+# will use the OpenSSL defaults for Diffie-Hellman key generation
+# It must be in PEM format!
+#tls_dhparams = /etc/sudo_logsrvd_dhparams.pem
+
+# TLS cipher list (see "CIPHER LIST FORMAT" in the OpenSSL manual)
+# NOTE that this setting is only effective if the negotiated protocol
+# is TLSver1.2.
+#tls_ciphers_v12 = HIGH:!aNULL
+
+# TLS cipher list if negotiated protocol is TLSver1.3
+# available ciphersuites are:
+#   TLS_AES_128_GCM_SHA256
+#   TLS_AES_256_GCM_SHA384
+#   TLS_CHACHA20_POLY1305_SHA256
+#   TLS_AES_128_CCM_SHA256
+#   TLS_AES_128_CCM_8_SHA256
+# multiple ciphersuites can be set separated by ':'
+# by default, all ciphersuites are enabled
+#tls_ciphers_v13 = TLS_AES_256_GCM_SHA384
+
+# Validate client certificates
+#tls_checkpeer = false
 
 [iolog]
 # The top-level directory to use when constructing the path name for the

--- a/examples/sudo_logsrvd.conf
+++ b/examples/sudo_logsrvd.conf
@@ -16,7 +16,11 @@
 # Multiple listen_address settings may be specified.
 # The default is to listen on all addresses.
 #listen_address = *:30344
-#
+
+# Sets timeout for the socket. If this parameter is not set,
+# the value will be 0 (no timeout)
+#timeout = 30
+
 # Sets audit server's communication over TLS on/off.
 # Minimum negotiable TLS version is 1.2
 #tls = true

--- a/logsrvd/Makefile.in
+++ b/logsrvd/Makefile.in
@@ -72,6 +72,8 @@ PIE_LDFLAGS = @PIE_LDFLAGS@
 SSP_CFLAGS = @SSP_CFLAGS@
 SSP_LDFLAGS = @SSP_LDFLAGS@
 
+OPENSSL_LIBS = @OPENSSL_LIBS@
+
 # cppcheck options, usually set in the top-level Makefile
 CPPCHECK_OPTS = -q --force --enable=warning,performance,portability --suppress=constStatement --error-exitcode=1 --inline-suppr -Dva_copy=va_copy -U__cplusplus -UQUAD_MAX -UQUAD_MIN -UUQUAD_MAX -U_POSIX_HOST_NAME_MAX -U_POSIX_PATH_MAX -U__NBBY -DNSIG=64
 
@@ -145,7 +147,7 @@ Makefile: $(srcdir)/Makefile.in
 	ifile=$<; rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $${ifile%i}c --i-file $< --output-file $@
 
 sudo_logsrvd: $(LOGSRVD_OBJS) $(LT_LIBS)
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LOGSRVD_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS)
+	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LOGSRVD_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS) $(OPENSSL_LIBS)
 
 sudo_sendlog: $(SENDLOG_OBJS) $(LT_LIBS)
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(SENDLOG_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS)

--- a/logsrvd/Makefile.in
+++ b/logsrvd/Makefile.in
@@ -150,7 +150,7 @@ sudo_logsrvd: $(LOGSRVD_OBJS) $(LT_LIBS)
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LOGSRVD_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS) $(OPENSSL_LIBS)
 
 sudo_sendlog: $(SENDLOG_OBJS) $(LT_LIBS)
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(SENDLOG_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS)
+	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(SENDLOG_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS) $(OPENSSL_LIBS)
 
 GENERATED = log_server.pb-c.h log_server.pb-c.c
 

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1150,7 +1150,7 @@ static void
 register_signal(int signo, struct sudo_event_base *base)
 {
     struct sudo_event *ev;
-    debug_decl(register_listener, SUDO_DEBUG_UTIL)
+    debug_decl(register_signal, SUDO_DEBUG_UTIL)
 
     ev = sudo_ev_alloc(signo, SUDO_EV_SIGNAL, signal_cb, base);
     if (ev == NULL)

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1226,6 +1226,7 @@ static int
 create_listener(struct listen_address *addr)
 {
     int flags, i, sock;
+    struct timeval timeout;
     debug_decl(create_listener, SUDO_DEBUG_UTIL)
 
     if ((sock = socket(addr->sa_un.sa.sa_family, SOCK_STREAM, 0)) == -1) {
@@ -1235,6 +1236,12 @@ create_listener(struct listen_address *addr)
     i = 1;
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i)) == -1)
 	sudo_warn("SO_REUSEADDR");
+    timeout.tv_sec = logsrvd_conf_get_sock_timeout();
+    timeout.tv_usec = 0;
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == -1)
+	sudo_warn("SO_RCVTIMEO");
+    if (setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == -1)
+	sudo_warn("SO_SNDTIMEO");
     if (bind(sock, &addr->sa_un.sa, addr->sa_len) == -1) {
 	sudo_warn("bind");
 	goto bad;

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -810,6 +810,126 @@ signal_cb(int signo, int what, void *v)
     debug_return;
 }
 
+static X509 *
+load_cert(const char *file)
+{
+    X509 *x509 = NULL;
+    BIO *cert = NULL;
+
+    debug_decl(load_cert, SUDO_DEBUG_UTIL)
+
+    if ((cert = BIO_new(BIO_s_file())) == NULL) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to allocate new BIO object for certificate: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    if (BIO_read_filename(cert, file) <= 0) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to read certificate file: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    x509 = PEM_read_bio_X509_AUX(cert, NULL, NULL, NULL);
+
+exit:
+    if (cert)
+        BIO_free(cert);
+
+    debug_return_ptr(x509);
+}
+
+static bool
+check_cert(X509_STORE *ca_store_ctx, SSL_CTX *ctx, const char *cert_file)
+{
+    bool ret = false;
+    X509_STORE_CTX *store_ctx = NULL;
+    X509 *x509 = NULL;
+
+    debug_decl(check_cert, SUDO_DEBUG_UTIL)
+
+    if ((x509 = load_cert(cert_file)) == NULL)
+        goto exit;
+
+    if ((store_ctx = X509_STORE_CTX_new()) == NULL) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to allocate X509_STORE_CTX object: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    X509_STORE_set_flags(ca_store_ctx, X509_V_FLAG_X509_STRICT);
+
+    if (!X509_STORE_CTX_init(store_ctx, ca_store_ctx, x509, 0)) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to initialize X509_STORE_CTX object: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    if (X509_verify_cert(store_ctx) <= 0) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to verify cert: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    /* everything is good, use this server certificate during TLS handshakes */
+    if (!SSL_CTX_use_certificate(ctx, x509)) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to load cert to the ssl context: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+
+    ret = true;
+exit:
+    X509_STORE_CTX_free(store_ctx);
+    X509_free(x509);
+
+    debug_return_bool(ret);
+}
+
+static bool
+verify_server_cert(SSL_CTX *ctx, const struct logsrvd_tls_config *tls_config)
+{
+    bool ret = false;
+    X509_STORE *ca_store_ctx = NULL;
+    X509_LOOKUP *x509_lookup = NULL;
+
+    debug_decl(verify_server_cert, SUDO_DEBUG_UTIL)
+
+    if ((ca_store_ctx = X509_STORE_new()) == NULL) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to allocate X509_STORE object for CA bundle: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    if ((x509_lookup = X509_STORE_add_lookup(ca_store_ctx, X509_LOOKUP_file())) == NULL) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to set lookup method: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    if(!X509_LOOKUP_load_file(x509_lookup, tls_config->cacert_path, X509_FILETYPE_PEM)) {
+        sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+            "unable to load CA bundle file: %s",
+            ERR_error_string(ERR_get_error(), NULL));
+        goto exit;
+    }
+
+    ret = check_cert(ca_store_ctx, ctx, tls_config->cert_path);
+
+exit:
+    X509_STORE_free(ca_store_ctx);
+
+    debug_return_bool(ret);
+}
 
 static bool
 init_tls_ciphersuites(SSL_CTX *ctx, const struct logsrvd_tls_config *tls_config)
@@ -903,6 +1023,29 @@ init_tls_server_context(void)
     if (!verify_server_cert(ctx, tls_config)) {
         goto bad;
     }
+
+    /* if peer authentication is enabled, verify client cert during TLS handshake */
+    if (tls_config->check_peer) {
+        X509 *cacert = load_cert(tls_config->cacert_path);
+
+        /* server will send the name of the CA to the client during the handshake */
+        if (SSL_CTX_add_client_CA(ctx, cacert) <= 0) {
+            sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+                "calling SSL_CTX_add_client_CA() failed: %s",
+                ERR_error_string(ERR_get_error(), NULL));
+        }
+
+        /* sets the location of the CA bundle file for verification purposes */
+        if (SSL_CTX_load_verify_locations(ctx, tls_config->cacert_path, NULL) <= 0) {
+            sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+                "calling SSL_CTX_load_verify_locations() failed: %s",
+                ERR_error_string(ERR_get_error(), NULL));
+        }
+
+        /* server will send a client certificate request to the peer during the handshake */
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+    }
+
     if (!SSL_CTX_use_PrivateKey_file(ctx, tls_config->pkey_path, SSL_FILETYPE_PEM)) {
         sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
             "unable to load key file: %s",

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1120,6 +1120,8 @@ connection_closure_alloc(int sock)
     if ((closure = calloc(1, sizeof(*closure))) == NULL)
 	debug_return_ptr(NULL);
 
+    TAILQ_INSERT_TAIL(&connections, closure, entries);
+
     if (logsrvd_conf_get_tls_opt() == true) {
         if ((closure->ssl = SSL_new(logsrvd_get_tls_runtime()->ssl_ctx)) == NULL) {
             sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
@@ -1167,7 +1169,6 @@ connection_closure_alloc(int sock)
     if (closure->write_ev == NULL)
 	goto bad;
 
-    TAILQ_INSERT_TAIL(&connections, closure, entries);
     debug_return_ptr(closure);
 bad:
     connection_closure_free(closure);

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -21,6 +21,8 @@
 # error protobuf-c version 1.30 or higher required
 #endif
 
+#include <openssl/ssl.h>
+
 #include "logsrv_util.h"
 
 /* Default listen address (port 30344 on all interfaces). */
@@ -81,6 +83,7 @@ struct connection_closure {
     struct sudo_event *commit_ev;
     struct sudo_event *read_ev;
     struct sudo_event *write_ev;
+    SSL *ssl;
     const char *errstr;
     struct iolog_file iolog_files[IOFD_MAX];
     int iolog_dir_fd;
@@ -105,6 +108,21 @@ struct listen_address {
     socklen_t sa_len;
 };
 TAILQ_HEAD(listen_address_list, listen_address);
+
+/* parameters to configure tls */
+struct logsrvd_tls_config {
+    char *pkey_path;
+    char *cert_path;
+    char *cacert_path;
+    char *dhparams_path;
+    char *ciphers_v12;
+    char *ciphers_v13;
+    bool check_peer;
+};
+
+struct logsrvd_tls_runtime {
+    SSL_CTX *ssl_ctx;
+};
 
 /* Supported eventlog types */
 enum logsrvd_eventlog_type {
@@ -138,6 +156,9 @@ bool logsrvd_conf_read(const char *path);
 const char *logsrvd_conf_iolog_dir(void);
 const char *logsrvd_conf_iolog_file(void);
 struct listen_address_list *logsrvd_conf_listen_address(void);
+bool logsrvd_conf_get_tls_opt(void);
+const struct logsrvd_tls_config *logsrvd_get_tls_config(void);
+struct logsrvd_tls_runtime *logsrvd_get_tls_runtime(void);
 enum logsrvd_eventlog_type logsrvd_conf_eventlog_type(void);
 enum logsrvd_eventlog_format logsrvd_conf_eventlog_format(void);
 unsigned int logsrvd_conf_syslog_maxlen(void);

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -32,6 +32,9 @@
 /* Default listen address (port 30344 on all interfaces). */
 #define DEFAULT_LISTEN_ADDR	"*:" DEFAULT_PORT_STR
 
+/* Default timeout value for server socket */
+#define DEFAULT_SOCKET_TIMEOUT_SEC 30
+
 /* How often to send an ACK to the client (commit point) in seconds */
 #define ACK_FREQUENCY	10
 
@@ -164,6 +167,7 @@ bool logsrvd_conf_read(const char *path);
 const char *logsrvd_conf_iolog_dir(void);
 const char *logsrvd_conf_iolog_file(void);
 struct listen_address_list *logsrvd_conf_listen_address(void);
+int logsrvd_conf_get_sock_timeout(void);
 #if defined(HAVE_OPENSSL)
 bool logsrvd_conf_get_tls_opt(void);
 const struct logsrvd_tls_config *logsrvd_get_tls_config(void);

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -21,7 +21,11 @@
 # error protobuf-c version 1.30 or higher required
 #endif
 
-#include <openssl/ssl.h>
+#include "config.h"
+
+#if defined(HAVE_OPENSSL)
+# include <openssl/ssl.h>
+#endif
 
 #include "logsrv_util.h"
 
@@ -83,7 +87,9 @@ struct connection_closure {
     struct sudo_event *commit_ev;
     struct sudo_event *read_ev;
     struct sudo_event *write_ev;
+#if defined(HAVE_OPENSSL)
     SSL *ssl;
+#endif
     const char *errstr;
     struct iolog_file iolog_files[IOFD_MAX];
     int iolog_dir_fd;
@@ -109,6 +115,7 @@ struct listen_address {
 };
 TAILQ_HEAD(listen_address_list, listen_address);
 
+#if defined(HAVE_OPENSSL)
 /* parameters to configure tls */
 struct logsrvd_tls_config {
     char *pkey_path;
@@ -123,6 +130,7 @@ struct logsrvd_tls_config {
 struct logsrvd_tls_runtime {
     SSL_CTX *ssl_ctx;
 };
+#endif
 
 /* Supported eventlog types */
 enum logsrvd_eventlog_type {
@@ -156,9 +164,11 @@ bool logsrvd_conf_read(const char *path);
 const char *logsrvd_conf_iolog_dir(void);
 const char *logsrvd_conf_iolog_file(void);
 struct listen_address_list *logsrvd_conf_listen_address(void);
+#if defined(HAVE_OPENSSL)
 bool logsrvd_conf_get_tls_opt(void);
 const struct logsrvd_tls_config *logsrvd_get_tls_config(void);
 struct logsrvd_tls_runtime *logsrvd_get_tls_runtime(void);
+#endif
 enum logsrvd_eventlog_type logsrvd_conf_eventlog_type(void);
 enum logsrvd_eventlog_format logsrvd_conf_eventlog_format(void);
 unsigned int logsrvd_conf_syslog_maxlen(void);

--- a/logsrvd/logsrvd_conf.c
+++ b/logsrvd/logsrvd_conf.c
@@ -67,10 +67,12 @@ struct logsrvd_config_section {
 
 static struct logsrvd_config {
     struct logsrvd_config_server {
-        bool tls;
         struct listen_address_list addresses;
+#if defined(HAVE_OPENSSL)
+        bool tls;
         struct logsrvd_tls_config tls_config;
         struct logsrvd_tls_runtime tls_runtime;
+#endif
     } server;
     struct logsrvd_config_iolog {
 	bool compress;
@@ -126,6 +128,7 @@ logsrvd_conf_listen_address(void)
     return &logsrvd_config->server.addresses;
 }
 
+#if defined(HAVE_OPENSSL)
 bool
 logsrvd_conf_get_tls_opt(void)
 {
@@ -143,6 +146,7 @@ logsrvd_get_tls_runtime(void)
 {
     return &logsrvd_config->server.tls_runtime;
 }
+#endif
 
 /* eventlog getters */
 enum logsrvd_eventlog_type
@@ -379,6 +383,7 @@ done:
     debug_return_bool(ret);
 }
 
+#if defined(HAVE_OPENSSL)
 static bool
 cb_tls_opt(struct logsrvd_config *config, const char *str)
 {
@@ -482,6 +487,7 @@ cb_tls_checkpeer(struct logsrvd_config *config, const char *str)
     config->server.tls_config.check_peer = val;
     debug_return_bool(true);
 }
+#endif
 
 /* eventlog callbacks */
 static bool
@@ -638,6 +644,7 @@ cb_logfile_time_format(struct logsrvd_config *config, const char *str)
 
 static struct logsrvd_config_entry server_conf_entries[] = {
     { "listen_address", cb_listen_address },
+#if defined(HAVE_OPENSSL)
     { "tls", cb_tls_opt },
     { "tls_key", cb_tls_key },
     { "tls_cacert", cb_tls_cacert },
@@ -646,6 +653,7 @@ static struct logsrvd_config_entry server_conf_entries[] = {
     { "tls_ciphers_v12", cb_tls_ciphers12 },
     { "tls_ciphers_v13", cb_tls_ciphers13 },
     { "tls_checkpeer", cb_tls_checkpeer },
+#endif
     { NULL }
 };
 

--- a/logsrvd/logsrvd_conf.c
+++ b/logsrvd/logsrvd_conf.c
@@ -67,7 +67,10 @@ struct logsrvd_config_section {
 
 static struct logsrvd_config {
     struct logsrvd_config_server {
-	struct listen_address_list addresses;
+        bool tls;
+        struct listen_address_list addresses;
+        struct logsrvd_tls_config tls_config;
+        struct logsrvd_tls_runtime tls_runtime;
     } server;
     struct logsrvd_config_iolog {
 	bool compress;
@@ -121,6 +124,24 @@ struct listen_address_list *
 logsrvd_conf_listen_address(void)
 {
     return &logsrvd_config->server.addresses;
+}
+
+bool
+logsrvd_conf_get_tls_opt(void)
+{
+    return logsrvd_config->server.tls;
+}
+
+const struct logsrvd_tls_config *
+logsrvd_get_tls_config(void)
+{
+    return &logsrvd_config->server.tls_config;
+}
+
+struct logsrvd_tls_runtime *
+logsrvd_get_tls_runtime(void)
+{
+    return &logsrvd_config->server.tls_runtime;
 }
 
 /* eventlog getters */
@@ -358,6 +379,110 @@ done:
     debug_return_bool(ret);
 }
 
+static bool
+cb_tls_opt(struct logsrvd_config *config, const char *str)
+{
+    int val;
+    debug_decl(cb_tls_opt, SUDO_DEBUG_UTIL)
+
+    if ((val = sudo_strtobool(str)) == -1)
+	debug_return_bool(false);
+
+    config->server.tls = val;
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_key(struct logsrvd_config *config, const char *path)
+{
+    debug_decl(cb_tls_key, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.pkey_path);
+    if ((config->server.tls_config.pkey_path = strdup(path)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_cacert(struct logsrvd_config *config, const char *path)
+{
+    debug_decl(cb_tls_cacert, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.cacert_path);
+    if ((config->server.tls_config.cacert_path = strdup(path)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_cert(struct logsrvd_config *config, const char *path)
+{
+    debug_decl(cb_tls_cert, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.cert_path);
+    if ((config->server.tls_config.cert_path = strdup(path)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_dhparam(struct logsrvd_config *config, const char *path)
+{
+    debug_decl(cb_tls_dhparam, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.dhparams_path);
+    if ((config->server.tls_config.dhparams_path = strdup(path)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_ciphers12(struct logsrvd_config *config, const char *str)
+{
+    debug_decl(cb_tls_ciphers12, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.ciphers_v12);
+    if ((config->server.tls_config.ciphers_v12 = strdup(str)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_ciphers13(struct logsrvd_config *config, const char *str)
+{
+    debug_decl(cb_tls_ciphers13, SUDO_DEBUG_UTIL)
+
+    free(config->server.tls_config.ciphers_v13);
+    if ((config->server.tls_config.ciphers_v13 = strdup(str)) == NULL) {
+        sudo_warn(NULL);
+        debug_return_bool(false);
+    }
+    debug_return_bool(true);
+}
+
+static bool
+cb_tls_checkpeer(struct logsrvd_config *config, const char *str)
+{
+    int val;
+    debug_decl(cb_tls_checkpeer, SUDO_DEBUG_UTIL)
+
+    if ((val = sudo_strtobool(str)) == -1)
+	debug_return_bool(false);
+
+    config->server.tls_config.check_peer = val;
+    debug_return_bool(true);
+}
+
 /* eventlog callbacks */
 static bool
 cb_eventlog_type(struct logsrvd_config *config, const char *str)
@@ -513,6 +638,14 @@ cb_logfile_time_format(struct logsrvd_config *config, const char *str)
 
 static struct logsrvd_config_entry server_conf_entries[] = {
     { "listen_address", cb_listen_address },
+    { "tls", cb_tls_opt },
+    { "tls_key", cb_tls_key },
+    { "tls_cacert", cb_tls_cacert },
+    { "tls_cert", cb_tls_cert },
+    { "tls_dhparams", cb_tls_dhparam },
+    { "tls_ciphers_v12", cb_tls_ciphers12 },
+    { "tls_ciphers_v13", cb_tls_ciphers13 },
+    { "tls_checkpeer", cb_tls_checkpeer },
     { NULL }
 };
 


### PR DESCRIPTION
This PR implements TLS layer for Sudo Audit Server using OpenSSL. The utility 'sudo_sendlog' has been updated as well to be able to communicate with the audit server over TLS.