### PR TITLE
Sudo audit Server - TLS protocol update

### DIFF
--- a/include/log_server.pb-c.h
+++ b/include/log_server.pb-c.h
@@ -405,10 +405,18 @@ struct  _ServerHello
    */
   size_t n_servers;
   char **servers;
+  /*
+   * true if server uses tls protocol 
+   */
+  protobuf_c_boolean tls;
+  /*
+   * true if client auth is required with signed cert 
+   */
+  protobuf_c_boolean tls_checkpeer;
 };
 #define SERVER_HELLO__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&server_hello__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL, 0, 0 }
 
 
 /* ClientMessage methods */

--- a/lib/logsrv/log_server.pb-c.c
+++ b/lib/logsrv/log_server.pb-c.c
@@ -1578,7 +1578,7 @@ const ProtobufCMessageDescriptor server_message__descriptor =
   (ProtobufCMessageInit) server_message__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor server_hello__field_descriptors[3] =
+static const ProtobufCFieldDescriptor server_hello__field_descriptors[5] =
 {
   {
     "server_id",
@@ -1616,16 +1616,42 @@ static const ProtobufCFieldDescriptor server_hello__field_descriptors[3] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "tls",
+    4,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_BOOL,
+    0,   /* quantifier_offset */
+    offsetof(ServerHello, tls),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "tls_checkpeer",
+    5,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_BOOL,
+    0,   /* quantifier_offset */
+    offsetof(ServerHello, tls_checkpeer),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned server_hello__field_indices_by_name[] = {
   1,   /* field[1] = redirect */
   0,   /* field[0] = server_id */
   2,   /* field[2] = servers */
+  3,   /* field[3] = tls */
+  4,   /* field[4] = tls_checkpeer */
 };
 static const ProtobufCIntRange server_hello__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 5 }
 };
 const ProtobufCMessageDescriptor server_hello__descriptor =
 {
@@ -1635,7 +1661,7 @@ const ProtobufCMessageDescriptor server_hello__descriptor =
   "ServerHello",
   "",
   sizeof(ServerHello),
-  3,
+  5,
   server_hello__field_descriptors,
   server_hello__field_indices_by_name,
   1,  server_hello__number_ranges,

--- a/lib/logsrv/log_server.proto
+++ b/lib/logsrv/log_server.proto
@@ -125,4 +125,6 @@ message ServerHello {
   string server_id = 1;		/* free-form server description */
   string redirect = 2;		/* optional redirect if busy */
   repeated string servers = 3;	/* optional list of known servers */
+  bool tls = 4;             /* true if server uses tls protocol */
+  bool tls_checkpeer = 5;   /* true if client auth is required with signed cert */
 }

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -167,6 +167,13 @@ fmt_hello_message(struct connection_buffer *buf)
 
     /* TODO: implement redirect and servers array.  */
     hello.server_id = (char *)server_id;
+#if defined(HAVE_OPENSSL)
+    hello.tls = logsrvd_conf_get_tls_opt();
+    hello.tls_checkpeer = logsrvd_get_tls_config()->check_peer;
+#else
+    hello.tls = false;
+    hello.tls_checkpeer = false;
+#endif
     msg.hello = &hello;
     msg.type_case = SERVER_MESSAGE__TYPE_HELLO;
 

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1248,7 +1248,7 @@ tls_handshake_cb(int fd, int what, void *v)
 
     /* Enable reader for ClientMessage */
     if (sudo_ev_add(base, closure->read_ev,
-        logsrvd_conf_get_sock_timeout(), false) == -1) {
+        NULL, false) == -1) {
         sudo_warn(U_("unable to add event to queue"));
     }
 
@@ -1360,12 +1360,12 @@ new_connection(int sock, struct sudo_event_base *base)
     } else {
         /* Enable reader for ClientMessage*/
         if (sudo_ev_add(base, closure->read_ev,
-            logsrvd_conf_get_sock_timeout(), false) == -1)
+            NULL, false) == -1)
             goto bad;
     }
 #else
     /* Enable reader for ClientMessage*/
-    if (sudo_ev_add(base, closure->read_ev, logsrvd_conf_get_sock_timeout(), false) == -1)
+    if (sudo_ev_add(base, closure->read_ev, NULL, false) == -1)
 	goto bad;
 #endif
 

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -91,6 +91,7 @@ struct connection_closure {
     struct sudo_event *read_ev;
     struct sudo_event *write_ev;
 #if defined(HAVE_OPENSSL)
+    struct sudo_event *ssl_accept_ev;
     SSL *ssl;
 #endif
     const char *errstr;

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -168,7 +168,7 @@ bool logsrvd_conf_read(const char *path);
 const char *logsrvd_conf_iolog_dir(void);
 const char *logsrvd_conf_iolog_file(void);
 struct listen_address_list *logsrvd_conf_listen_address(void);
-int logsrvd_conf_get_sock_timeout(void);
+struct timespec *logsrvd_conf_get_sock_timeout(void);
 #if defined(HAVE_OPENSSL)
 bool logsrvd_conf_get_tls_opt(void);
 const struct logsrvd_tls_config *logsrvd_get_tls_config(void);

--- a/logsrvd/sendlog.h
+++ b/logsrvd/sendlog.h
@@ -35,12 +35,17 @@ enum client_state {
 };
 
 struct client_closure {
+    int sock;
     struct timespec *restart;
     struct timespec *elapsed;
     struct timespec committed;
     struct timing_closure timing;
     struct connection_buffer read_buf;
     struct connection_buffer write_buf;
+#if defined(HAVE_OPENSSL)
+    struct sudo_event *tls_connect_ev;
+    bool tls_connect_state;
+#endif
     struct sudo_event *read_ev;
     struct sudo_event *write_ev;
     struct iolog_info *log_info;


### PR DESCRIPTION
Modifications
- Two new fields (tls, tls_checkpeer) have been added to the ServerHello message in log_sever.proto 
- ServerHello message is unencrypted now in every case and contains the tls and tls_checkpeer fields
- TLS communication has been refactored to do everything asynchronous
- Audit server now operates with event timeout instead of socket timeout
Known issues:
- if sudo is compiled WITHOUT --enable-openssl, but sudo_logsrvd.conf contains config options for tls, logsrvd throws Segmentation Fault at startup (unknown key)