### PR TITLE
Audit Server - add default values for cert paths

### DIFF
--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1143,7 +1143,10 @@ init_tls_server_context(void)
         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
     }
 
-    if (!SSL_CTX_use_PrivateKey_file(ctx, tls_config->pkey_path, SSL_FILETYPE_PEM)) {
+    /* if private key file was not set, assume that the cert file contains the private key */
+    char* pkey = (tls_config->pkey_path == NULL ? tls_config->cert_path : tls_config->pkey_path);
+
+    if (!SSL_CTX_use_PrivateKey_file(ctx, pkey, SSL_FILETYPE_PEM)) {
         sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
             "unable to load key file: %s",
             ERR_error_string(ERR_get_error(), NULL));

--- a/logsrvd/logsrvd_conf.c
+++ b/logsrvd/logsrvd_conf.c
@@ -52,6 +52,11 @@
 #include "pathnames.h"
 #include "logsrvd.h"
 
+#if defined(HAVE_OPENSSL)
+# define DEFAULT_CA_CERT_PATH       "/etc/ssl/sudo/cacert.pem"
+# define DEFAULT_SERVER_CERT_PATH   "/etc/ssl/sudo/logsrvd_cert.pem"
+#endif
+
 struct logsrvd_config;
 typedef bool (*logsrvd_conf_cb_t)(struct logsrvd_config *config, const char *);
 
@@ -852,6 +857,11 @@ logsrvd_conf_alloc(void)
     /* Server defaults */
     TAILQ_INIT(&config->server.addresses);
     config->server.timeout.tv_sec = DEFAULT_SOCKET_TIMEOUT_SEC;
+
+#if defined(HAVE_OPENSSL)
+    config->server.tls_config.cacert_path = strdup(DEFAULT_CA_CERT_PATH);
+    config->server.tls_config.cert_path = strdup(DEFAULT_SERVER_CERT_PATH);
+#endif
 
     /* I/O log defaults */
     config->iolog.compress = false;


### PR DESCRIPTION
This PR fixes issues when various cert and key paths are not set in sudo_logsrvd.conf.
- CA cert and server cert path default values are the same as in examples/sudo_logsrvd.conf.
- If private key file is not set in the config, the audit server tries to load it from the cert file.