### PR TITLE
Client/Server Identity validation for the audit server

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -79,6 +79,7 @@ include/compat/sha2.h
 include/compat/stdbool.h
 include/log_server.pb-c.h
 include/protobuf-c/protobuf-c.h
+lib/iolog/hostcheck.h
 include/sudo_compat.h
 include/sudo_conf.h
 include/sudo_debug.h
@@ -95,6 +96,7 @@ include/sudo_rand.h
 include/sudo_util.h
 install-sh
 lib/iolog/Makefile.in
+lib/iolog/hostcheck.c
 lib/iolog/iolog_fileio.c
 lib/iolog/iolog_path.c
 lib/iolog/iolog_util.c

--- a/include/hostcheck.h
+++ b/include/hostcheck.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Laszlo Orban <laszlo.orban@oneidentity.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef SUDO_HOSTCHECK_H
+#define SUDO_HOSTCHECK_H
+
+#if defined(HAVE_OPENSSL)
+
+# include <openssl/x509v3.h>
+# include "sudo_compat.h"
+
+typedef enum {
+	MatchFound,
+	MatchNotFound,
+	NoSANPresent,
+	MalformedCertificate,
+	Error
+} HostnameValidationResult;
+
+__dso_public HostnameValidationResult
+validate_hostname(const X509 *cert, const char *hostname, const char *ipaddr, int resolve);
+
+#endif /* HAVE_OPENSSL */
+
+#endif /* SUDO_HOSTCHECK_H */

--- a/lib/iolog/Makefile.in
+++ b/lib/iolog/Makefile.in
@@ -82,7 +82,7 @@ DEVEL = @DEVEL@
 
 SHELL = @SHELL@
 
-LIBIOLOG_OBJS = iolog_fileio.lo iolog_path.lo iolog_util.lo
+LIBIOLOG_OBJS = iolog_fileio.lo iolog_path.lo iolog_util.lo hostcheck.lo
 
 IOBJS = $(LIBIOLOG_OBJS:.lo=.i)
 
@@ -201,6 +201,14 @@ check_iolog_util.i: $(srcdir)/regress/iolog_util/check_iolog_util.c \
 	$(CC) -E -o $@ $(CPPFLAGS) $<
 check_iolog_util.plog: check_iolog_util.i
 	rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $(srcdir)/regress/iolog_util/check_iolog_util.c --i-file $< --output-file $@
+hostcheck.lo: $(srcdir)/hostcheck.c $(incdir)/hostcheck.h \
+              $(incdir)/sudo_compat.h $(top_builddir)/config.h
+	$(LIBTOOL) $(LTFLAGS) --mode=compile $(CC) -c -o $@ $(CPPFLAGS) $(CFLAGS) $(ASAN_CFLAGS) $(PIE_CFLAGS) $(SSP_CFLAGS) $(srcdir)/hostcheck.c
+hostcheck.i: $(srcdir)/hostcheck.c $(incdir)/hostcheck.h \
+              $(incdir)/sudo_compat.h $(top_builddir)/config.h
+	$(CC) -E -o $@ $(CPPFLAGS) $<
+hostcheck.plog: hostcheck.i
+	rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $(srcdir)/hostcheck.c --i-file $< --output-file $@
 iolog_fileio.lo: $(srcdir)/iolog_fileio.c $(incdir)/compat/stdbool.h \
                  $(incdir)/sudo_compat.h $(incdir)/sudo_conf.h \
                  $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \

--- a/lib/iolog/hostcheck.c
+++ b/lib/iolog/hostcheck.c
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2020 Laszlo Orban <laszlo.orban@oneidentity.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+
+#if defined(HAVE_OPENSSL)
+# include <string.h>
+# include <netdb.h>
+# include <sys/socket.h>
+# include <arpa/inet.h>
+# include <openssl/x509v3.h>
+
+# include  "hostcheck.h"
+
+/**
+ * @brief Checks if given hostname resolves to the given IP address.
+ *
+ * @param hostname  hostname to be resolved
+ * @param ipaddr    ip address to be checked
+ * 
+ * @return  1 if hostname resolves to the given IP address
+ *          0 otherwise
+ */
+static int
+forward_lookup_match(const char *hostname, const char *ipaddr)
+{
+    int ret = 0;
+    struct addrinfo *res = NULL, *p;
+    void *addr;
+    struct sockaddr_in *ipv4;
+#if defined(HAVE_STRUCT_IN6_ADDR)
+    struct sockaddr_in6 *ipv6;
+    char ipstr[INET6_ADDRSTRLEN];
+#else
+    char ipstr[INET_ADDRSTRLEN];
+#endif
+
+    if (getaddrinfo(hostname, NULL, NULL, &res) != 0) {
+        goto exit;
+    }
+
+    for(p = res ;p != NULL; p = p->ai_next) {
+        if(p->ai_family == AF_INET) {
+            ipv4 = (struct sockaddr_in *)p->ai_addr;
+            addr = &(ipv4->sin_addr);
+#if defined(HAVE_STRUCT_IN6_ADDR)
+        } else if(p->ai_family == AF_INET6) {
+            ipv6 = (struct sockaddr_in6 *)p->ai_addr;
+            addr = &(ipv6->sin6_addr);
+#endif
+        } else {
+            goto exit;
+        }
+
+        if (inet_ntop(p->ai_family, addr, ipstr, sizeof(ipstr)) != 0) {
+            if (strcmp(ipaddr, ipstr) == 0) {
+                ret = 1;
+                break;
+            }
+        }
+    }
+
+exit:
+    if (res != NULL) {
+        freeaddrinfo(res);
+    }
+    return ret;
+}
+
+/**
+ * @brief Compares the given hostname with a DNS entry in a certificate.
+ *
+ * The certificate DNS name can contain wildcards in the left-most label.
+ * A wildcard can match only one label.
+ * Accepted names:
+ *  - foo.bar.example.com
+ *  - *.example.com
+ *  - *.bar.example.com
+ * 
+ * @param hostname          peer's name
+ * @param certname_asn1     hostname in the certificate
+ * 
+ * @return  MatchFound
+ *          MatchNotFound
+ */
+static HostnameValidationResult
+validate_name(const char *hostname, ASN1_STRING *certname_asn1) {
+	char *certname_s = (char *) ASN1_STRING_get0_data(certname_asn1);
+	int certname_len = ASN1_STRING_length(certname_asn1);
+    int hostname_len = strlen(hostname);
+
+	/* remove last '.' from hostname if exists */
+	if (hostname_len != 0 && hostname[hostname_len - 1] == '.') {
+		--hostname_len;
+    }
+
+	/* skip the first label if wildcard */
+	if (certname_len > 2 && certname_s[0] == '*' && certname_s[1] == '.') {
+		if (hostname_len != 0) {
+			do {
+				--hostname_len;
+				if (*hostname++ == '.') {
+					break;
+                }
+			} while (hostname_len != 0);
+		}
+		certname_s += 2;
+		certname_len -= 2;
+	}
+	/* Compare expected hostname with the DNS name */
+	if (certname_len != hostname_len) {
+		return MatchNotFound;
+	}
+    if (strncasecmp(hostname, certname_s, hostname_len) != 0) {
+        return MatchNotFound;
+    }
+
+    return MatchFound;
+}
+
+/**
+ * @brief Matches a hostname with the cert's CN.
+ * 
+ * @param hostname  peer's name
+ *                  on client side: it is the name where the client is connected to
+ *                  on server side, it is in fact an IP address of the remote client
+ * @param ipaddr    peer's IP address
+ * @param cert      peer's X509 certificate
+ * @param resolve   if the value is not 0, the function checks that the value of the CN
+ *                  resolves to the given ipaddr or not.
+ * 
+ * @return  MatchFound
+ *          MatchNotFound
+ *          MalformedCertificate
+ *          Error
+ */
+static HostnameValidationResult
+matches_common_name(const char *hostname, const char *ipaddr, const X509 *cert, int resolve)
+{
+	X509_NAME_ENTRY *common_name_entry = NULL;
+	ASN1_STRING *common_name_asn1 = NULL;
+ 	int common_name_loc = -1;
+
+	/* Find the position of the CN field in the Subject field of the certificate */
+	common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *) cert), NID_commonName, -1);
+	if (common_name_loc < 0) {
+		return Error;
+	}
+
+	/* Extract the CN field */
+	common_name_entry = X509_NAME_get_entry(X509_get_subject_name((X509 *) cert), common_name_loc);
+	if (common_name_entry == NULL) {
+		return Error;
+	}
+
+	/* Convert the CN field to a C string */
+	common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
+	if (common_name_asn1 == NULL) {
+		return Error;
+	}			
+	const unsigned char *common_name_str = ASN1_STRING_get0_data(common_name_asn1);
+
+	/* Make sure there isn't an embedded NUL character in the CN */
+    if (memchr(common_name_str, '\0', ASN1_STRING_length(common_name_asn1)) != NULL) {
+		return MalformedCertificate;
+	}
+
+	/* Compare expected hostname with the CN */
+    if (validate_name(hostname, common_name_asn1) == MatchFound) {
+		return MatchFound;
+	}
+
+    int common_name_length = ASN1_STRING_length(common_name_asn1);
+    unsigned char *nullterm_common_name = malloc(common_name_length + 1);
+
+    if (nullterm_common_name == NULL) {
+        return Error;
+    }
+
+    memcpy(nullterm_common_name, common_name_str, common_name_length);
+    nullterm_common_name[common_name_length] = '\0';
+
+
+    /* check if hostname in the CN field resolves to the given ip address */
+    if (resolve && forward_lookup_match(nullterm_common_name, ipaddr)) {
+        free(nullterm_common_name);
+		return MatchFound;
+    }
+
+    free(nullterm_common_name);
+    return MatchNotFound;
+}
+
+/**
+ * @brief Matches a hostname or ipaddr with the cert's corresponding SAN field.
+ *
+ * SAN can have different fields. For hostname matching, the GEN_DNS field is used,
+ * for IP address matching, the GEN_IPADD field is used.
+ * Since SAN is an X503 v3 extension, it can happen that the cert does
+ * not contain SAN at all.
+ * 
+ * @param hostname  remote peer's name
+ *                  on client side: it is the name where the client is connected to
+ *                  on server side, it is in fact an IP address of the remote client
+ * @param ipaddr    remote peer's IP address
+ * @param cert      peer's X509 certificate
+ * @param resolve   if the value is not 0, the function checks that the value of the
+ *                  SAN GEN_DNS resolves to the given ipaddr or not.
+ * 
+ * @return  MatchFound
+ *          MatchNotFound
+ *          NoSANPresent
+ *          MalformedCertificate
+ *          Error
+ */
+static HostnameValidationResult
+matches_subject_alternative_name(const char *hostname, const char *ipaddr, const X509 *cert, int resolve)
+{
+    HostnameValidationResult result = MatchNotFound;
+    int i;
+    int san_names_nb = -1;
+    STACK_OF(GENERAL_NAME) *san_names = NULL;
+
+    /* Try to extract the names within the SAN extension from the certificate */
+    san_names = X509_get_ext_d2i((X509 *) cert, NID_subject_alt_name, NULL, NULL);
+    if (san_names == NULL) {
+        return NoSANPresent;
+    }
+    san_names_nb = sk_GENERAL_NAME_num(san_names);
+
+    /* Check each name within the extension */
+    for (i=0; i<san_names_nb; i++) {
+        const GENERAL_NAME *current_name = sk_GENERAL_NAME_value(san_names, i);
+
+        if (current_name->type == GEN_DNS) {
+            const unsigned char *dns_name = ASN1_STRING_get0_data(current_name->d.dNSName);
+
+            /* Make sure there isn't an embedded NUL character in the DNS name */
+            if (memchr(dns_name, '\0', ASN1_STRING_length(current_name->d.dNSName)) != NULL) {
+                result = MalformedCertificate;
+                break;
+            } else {
+                /* Compare expected hostname with the DNS name */
+                if (validate_name(hostname, current_name->d.dNSName) == MatchFound) {
+                    result = MatchFound;
+                    break;
+                }
+
+                int dns_name_length = ASN1_STRING_length(current_name->d.dNSName);
+                unsigned char *nullterm_dns_name = malloc(dns_name_length + 1);
+
+                if (nullterm_dns_name == NULL) {
+                    return Error;
+                }
+
+                memcpy(nullterm_dns_name, dns_name, dns_name_length);
+                nullterm_dns_name[dns_name_length] = '\0';
+
+                if (resolve && forward_lookup_match(nullterm_dns_name, ipaddr)) {
+                    free(nullterm_dns_name);
+                    result = MatchFound;
+                    break;
+                }
+                free(nullterm_dns_name);
+            }
+        } else if (current_name->type == GEN_IPADD) {
+            const unsigned char *san_ip = ASN1_STRING_get0_data(current_name->d.iPAddress);
+#if defined(HAVE_STRUCT_IN6_ADDR)
+            char san_ip_str[INET6_ADDRSTRLEN];
+#else
+            char san_ip_str[INET_ADDRSTRLEN];
+#endif
+
+            /* IPV4 address */
+            if(current_name->d.iPAddress->length == 4) {
+                if (inet_ntop(AF_INET, san_ip, san_ip_str, INET_ADDRSTRLEN) == NULL) {
+                    result = MalformedCertificate;
+                    break;
+                }
+#if defined(HAVE_STRUCT_IN6_ADDR)
+            /* IPV6 address */
+            } else if (current_name->d.iPAddress->length == 16) {
+                if (inet_ntop(AF_INET6, san_ip, san_ip_str, INET6_ADDRSTRLEN) == NULL) {
+                    result = MalformedCertificate;
+                    break;
+                }
+# endif
+            } else {
+                result = MalformedCertificate;
+                break;
+            }
+
+            if (strcasecmp(ipaddr, san_ip_str) == 0) {
+                result = MatchFound;
+                break;
+            }
+        }
+    }
+    sk_GENERAL_NAME_pop_free(san_names, GENERAL_NAME_free);
+
+    return result;
+}
+
+/**
+ * @brief Do hostname/IP validation on the given X509 certificate.
+ *
+ * According to RFC 6125 section 6.4.4, first the certificate's SAN field
+ * has to be checked. If there is no SAN field, the certificate's CN field
+ * has to be checked.
+ * 
+ * @param cert      X509 certificate
+ * @param hostname  remote peer's name
+ *                  on client side: it is the name where the client is connected to
+ *                  on server side, it is in fact an IP address of the remote client
+ * @param ipaddr    remote peer's IP address
+ * @param resolve   if the value is not 0, the function checks that the value of the
+ *                  SAN GEN_DNS or the value of CN resolves to the given ipaddr or not.
+ * 
+ * @return  MatchFound
+ *          MatchNotFound
+ *          MalformedCertificate
+ *          Error
+ */
+HostnameValidationResult
+validate_hostname(const X509 *cert, const char *hostname, const char *ipaddr, int resolve)
+{
+    HostnameValidationResult res = MatchFound;
+
+    /* hostname can be also an ip address, if client connects
+     * to ip instead of FQDN
+     */
+    if((ipaddr == NULL) || (cert == NULL)) {
+        return Error;
+    }
+
+    /* check SAN first if exists */
+    res = matches_subject_alternative_name(hostname, ipaddr, cert, resolve);
+
+    /* According to RFC 6125 section 6.4.4, check CN only,
+     * if no SAN name was provided
+     */
+    if (res == NoSANPresent) {
+        res = matches_common_name(hostname, ipaddr, cert, resolve);
+    }
+
+    return res;
+}
+#endif /* HAVE_OPENSSL */

--- a/logsrvd/Makefile.in
+++ b/logsrvd/Makefile.in
@@ -254,18 +254,20 @@ logsrv_util.i: $(srcdir)/logsrv_util.c $(incdir)/compat/stdbool.h \
 logsrv_util.plog: logsrv_util.i
 	rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $(srcdir)/logsrv_util.c --i-file $< --output-file $@
 logsrvd.o: $(srcdir)/logsrvd.c $(incdir)/compat/getopt.h \
-           $(incdir)/compat/stdbool.h $(incdir)/log_server.pb-c.h \
-           $(incdir)/protobuf-c/protobuf-c.h $(incdir)/sudo_compat.h \
-           $(incdir)/sudo_conf.h $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
+           $(incdir)/compat/stdbool.h $(incdir)/hostcheck.h \
+           $(incdir)/log_server.pb-c.h $(incdir)/protobuf-c/protobuf-c.h \
+           $(incdir)/sudo_compat.h $(incdir)/sudo_conf.h \
+           $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
            $(incdir)/sudo_fatal.h $(incdir)/sudo_gettext.h \
            $(incdir)/sudo_iolog.h $(incdir)/sudo_queue.h $(incdir)/sudo_rand.h \
            $(incdir)/sudo_util.h $(srcdir)/logsrv_util.h $(srcdir)/logsrvd.h \
            $(top_builddir)/config.h $(top_builddir)/pathnames.h
 	$(CC) -c $(CPPFLAGS) $(CFLAGS) $(ASAN_CFLAGS) $(PIE_CFLAGS) $(SSP_CFLAGS) $(srcdir)/logsrvd.c
 logsrvd.i: $(srcdir)/logsrvd.c $(incdir)/compat/getopt.h \
-           $(incdir)/compat/stdbool.h $(incdir)/log_server.pb-c.h \
-           $(incdir)/protobuf-c/protobuf-c.h $(incdir)/sudo_compat.h \
-           $(incdir)/sudo_conf.h $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
+           $(incdir)/compat/stdbool.h $(incdir)/hostcheck.h \
+           $(incdir)/log_server.pb-c.h $(incdir)/protobuf-c/protobuf-c.h \
+           $(incdir)/sudo_compat.h $(incdir)/sudo_conf.h \
+           $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
            $(incdir)/sudo_fatal.h $(incdir)/sudo_gettext.h \
            $(incdir)/sudo_iolog.h $(incdir)/sudo_queue.h $(incdir)/sudo_rand.h \
            $(incdir)/sudo_util.h $(srcdir)/logsrv_util.h $(srcdir)/logsrvd.h \

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 
 #include <errno.h>
 #include <fcntl.h>
@@ -43,6 +44,7 @@
 #if defined(HAVE_OPENSSL)
 # include <openssl/ssl.h>
 # include <openssl/err.h>
+# include "hostcheck.h"
 #endif
 
 #include "log_server.pb-c.h"
@@ -909,6 +911,45 @@ signal_cb(int signo, int what, void *v)
 }
 
 #if defined(HAVE_OPENSSL)
+static int
+verify_peer_identity(int preverify_ok, X509_STORE_CTX *ctx)
+{
+    HostnameValidationResult result;
+    struct connection_closure *closure;
+    SSL *ssl;
+    X509 *current_cert;
+    X509 *peer_cert;
+
+    /* if pre-verification of the cert failed, just propagate that result back */
+    if (preverify_ok != 1) {
+        return 0;
+    }
+
+    /* since this callback is called for each cert in the chain,
+     * check that current cert is the peer's certificate
+     */
+    current_cert = X509_STORE_CTX_get_current_cert(ctx);
+    peer_cert = X509_STORE_CTX_get0_cert(ctx);
+
+    if (current_cert != peer_cert) {
+        return 1;
+    }
+
+    /* read out the attached object (closure) from the ssl connection object */
+    ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+    closure = (struct connection_closure *)SSL_get_ex_data(ssl, 1);
+
+    result = validate_hostname(peer_cert, closure->ipaddr, closure->ipaddr, 1);
+
+    switch(result)
+    {
+        case MatchFound:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 static bool
 verify_server_cert(SSL_CTX *ctx, const struct logsrvd_tls_config *tls_config)
 {
@@ -1085,9 +1126,12 @@ init_tls_server_context(void)
         goto bad;
     }
 
-    /* if peer authentication is enabled, verify client cert during TLS handshake */
+    /* if peer authentication is enabled, verify client cert during TLS handshake
+     * The last parameter is a callback, where identity validation (hostname/ip)
+     * will be performed, because it is not automatically done by openssl.
+     */
     if (tls_config->check_peer) {
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, verify_peer_identity);
     }
 
     /* if private key file was not set, assume that the cert file contains the private key */
@@ -1264,7 +1308,7 @@ bad:
  * Allocate a connection closure and send a server hello message.
  */
 static bool
-new_connection(int sock, struct sudo_event_base *base)
+new_connection(int sock, const struct sockaddr *sa, struct sudo_event_base *base)
 {
     struct connection_closure *closure;
 
@@ -1301,6 +1345,15 @@ new_connection(int sock, struct sudo_event_base *base)
             goto bad;
         }
 
+        /* attach the closure object to the ssl connection object to make it
+        available during hostname matching
+        */
+        if (SSL_set_ex_data(closure->ssl, 1, closure) <= 0) {
+            sudo_warnx(U_("Unable to attach user data to the ssl object: %s"),
+                ERR_error_string(ERR_get_error(), NULL));
+            goto bad;
+        }
+
         /* enable SSL_accept to begin handshake with client */
         if (sudo_ev_add(base, closure->ssl_accept_ev,
             logsrvd_conf_get_sock_timeout(), false) == -1) {
@@ -1318,6 +1371,24 @@ new_connection(int sock, struct sudo_event_base *base)
     if (sudo_ev_add(base, closure->read_ev, NULL, false) == -1)
 	goto bad;
 #endif
+
+    /* store the peer's IP address in the closure object*/
+    if (sa->sa_family == AF_INET) {
+        struct sockaddr_in *sin = (struct sockaddr_in *)sa;
+        inet_ntop(AF_INET, &sin->sin_addr, closure->ipaddr,
+            sizeof(closure->ipaddr));
+    }
+#if defined(HAVE_STRUCT_IN6_ADDR)
+    else if (sa->sa_family == AF_INET6){
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)sa;
+        inet_ntop(AF_INET6, &sin6->sin6_addr, closure->ipaddr,
+            sizeof(closure->ipaddr));
+    }
+#endif /* HAVE_STRUCT_IN6_ADDR */
+    else {
+        sudo_fatal(U_("unable to get remote IP addr"));
+        goto bad;
+    }
 
     debug_return_bool(true);
 bad:
@@ -1370,7 +1441,7 @@ listener_cb(int fd, int what, void *v)
 
     sock = accept(fd, &s_un.sa, &salen);
     if (sock != -1) {
-	if (!new_connection(sock, base)) {
+	if (!new_connection(sock, &s_un.sa, base)) {
 	    /* TODO: pause accepting on ENOMEM */
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
 		"unable to start new connection");

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -98,6 +98,11 @@ struct connection_closure {
     struct iolog_file iolog_files[IOFD_MAX];
     int iolog_dir_fd;
     int sock;
+#ifdef HAVE_STRUCT_IN6_ADDR
+    char ipaddr[INET6_ADDRSTRLEN];
+#else
+    char ipaddr[INET_ADDRSTRLEN];
+#endif
     enum connection_status state;
 };
 

--- a/plugins/sudoers/Makefile.in
+++ b/plugins/sudoers/Makefile.in
@@ -1525,29 +1525,31 @@ iolog.plog: iolog.i
 	rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $(srcdir)/iolog.c --i-file $< --output-file $@
 iolog_client.lo: $(srcdir)/iolog_client.c $(devdir)/def_data.h \
                  $(incdir)/compat/getaddrinfo.h $(incdir)/compat/stdbool.h \
-                 $(incdir)/log_server.pb-c.h $(incdir)/protobuf-c/protobuf-c.h \
-                 $(incdir)/sudo_compat.h $(incdir)/sudo_conf.h \
-                 $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
-                 $(incdir)/sudo_fatal.h $(incdir)/sudo_gettext.h \
-                 $(incdir)/sudo_plugin.h $(incdir)/sudo_queue.h \
-                 $(incdir)/sudo_util.h $(srcdir)/defaults.h \
-                 $(srcdir)/iolog_plugin.h $(srcdir)/logging.h \
-                 $(srcdir)/parse.h $(srcdir)/strlist.h $(srcdir)/sudo_nss.h \
-                 $(srcdir)/sudoers.h $(srcdir)/sudoers_debug.h \
-                 $(top_builddir)/config.h $(top_builddir)/pathnames.h
+                 $(incdir)/hostcheck.h $(incdir)/log_server.pb-c.h \
+                 $(incdir)/protobuf-c/protobuf-c.h $(incdir)/sudo_compat.h \
+                 $(incdir)/sudo_conf.h $(incdir)/sudo_debug.h \
+                 $(incdir)/sudo_event.h $(incdir)/sudo_fatal.h \
+                 $(incdir)/sudo_gettext.h $(incdir)/sudo_plugin.h \
+                 $(incdir)/sudo_queue.h $(incdir)/sudo_util.h \
+                 $(srcdir)/defaults.h $(srcdir)/iolog_plugin.h \
+                 $(srcdir)/logging.h $(srcdir)/parse.h $(srcdir)/strlist.h \
+                 $(srcdir)/sudo_nss.h $(srcdir)/sudoers.h \
+                 $(srcdir)/sudoers_debug.h $(top_builddir)/config.h \
+                 $(top_builddir)/pathnames.h
 	$(LIBTOOL) $(LTFLAGS) --mode=compile $(CC) -c $(CPPFLAGS) $(CFLAGS) $(ASAN_CFLAGS) $(PIE_CFLAGS) $(SSP_CFLAGS) $(srcdir)/iolog_client.c
 iolog_client.i: $(srcdir)/iolog_client.c $(devdir)/def_data.h \
                  $(incdir)/compat/getaddrinfo.h $(incdir)/compat/stdbool.h \
-                 $(incdir)/log_server.pb-c.h $(incdir)/protobuf-c/protobuf-c.h \
-                 $(incdir)/sudo_compat.h $(incdir)/sudo_conf.h \
-                 $(incdir)/sudo_debug.h $(incdir)/sudo_event.h \
-                 $(incdir)/sudo_fatal.h $(incdir)/sudo_gettext.h \
-                 $(incdir)/sudo_plugin.h $(incdir)/sudo_queue.h \
-                 $(incdir)/sudo_util.h $(srcdir)/defaults.h \
-                 $(srcdir)/iolog_plugin.h $(srcdir)/logging.h \
-                 $(srcdir)/parse.h $(srcdir)/strlist.h $(srcdir)/sudo_nss.h \
-                 $(srcdir)/sudoers.h $(srcdir)/sudoers_debug.h \
-                 $(top_builddir)/config.h $(top_builddir)/pathnames.h
+                 $(incdir)/hostcheck.h $(incdir)/log_server.pb-c.h \
+                 $(incdir)/protobuf-c/protobuf-c.h $(incdir)/sudo_compat.h \
+                 $(incdir)/sudo_conf.h $(incdir)/sudo_debug.h \
+                 $(incdir)/sudo_event.h $(incdir)/sudo_fatal.h \
+                 $(incdir)/sudo_gettext.h $(incdir)/sudo_plugin.h \
+                 $(incdir)/sudo_queue.h $(incdir)/sudo_util.h \
+                 $(srcdir)/defaults.h $(srcdir)/iolog_plugin.h \
+                 $(srcdir)/logging.h $(srcdir)/parse.h $(srcdir)/strlist.h \
+                 $(srcdir)/sudo_nss.h $(srcdir)/sudoers.h \
+                 $(srcdir)/sudoers_debug.h $(top_builddir)/config.h \
+                 $(top_builddir)/pathnames.h
 	$(CC) -E -o $@ $(CPPFLAGS) $<
 iolog_client.plog: iolog_client.i
 	rm -f $@; pvs-studio --cfg $(PVS_CFG) --sourcetree-root $(top_srcdir) --skip-cl-exe yes --source-file $(srcdir)/iolog_client.c --i-file $< --output-file $@

--- a/plugins/sudoers/iolog_client.c
+++ b/plugins/sudoers/iolog_client.c
@@ -181,7 +181,8 @@ connect_server(const char *host, const char *port, struct timespec *timo,
  * Returns a socket with O_NONBLOCK and close-on-exec flags set.
  */
 int
-log_server_connect(struct sudoers_str_list *servers, struct timespec *timo)
+log_server_connect(struct sudoers_str_list *servers, struct timespec *timo,
+    struct sudoers_string **connected_server)
 {
     struct sudoers_string *server;
     char *copy, *host, *port;
@@ -204,6 +205,8 @@ log_server_connect(struct sudoers_str_list *servers, struct timespec *timo)
 		close(sock);
 		sock = -1;
 	    }
+        /* this is the server we successfully connected to */
+        *connected_server = server;
 	    break;
 	}
     }

--- a/plugins/sudoers/iolog_plugin.h
+++ b/plugins/sudoers/iolog_plugin.h
@@ -86,6 +86,12 @@ enum client_state {
 /* Remote connection closure, non-zero fields must come first. */
 struct client_closure {
     int sock;
+    struct sudoers_string *host;
+#if defined(HAVE_STRUCT_IN6_ADDR)
+    char ipaddr[INET6_ADDRSTRLEN];
+#else
+    char ipaddr[INET_ADDRSTRLEN];
+#endif
 #if defined(HAVE_OPENSSL)
     bool tls;
     bool tls_conn_status;
@@ -113,6 +119,8 @@ struct client_closure {
 # define CLIENT_CLOSURE_INITIALIZER(_c)			\
     {							\
 	-1,						    \
+	NULL,					    \
+	"", 					    \
     false,                      \
     false,                      \
     NULL,						\
@@ -126,6 +134,8 @@ struct client_closure {
 # define CLIENT_CLOSURE_INITIALIZER(_c)			\
     {							\
 	-1,						\
+	NULL,					    \
+	"", 					    \
 	ERROR,						\
 	false,						\
 	TAILQ_HEAD_INITIALIZER((_c).write_bufs),	\
@@ -142,7 +152,7 @@ bool fmt_exit_message(struct client_closure *closure, int exit_status, int error
 bool fmt_io_buf(struct client_closure *closure, int type, const char *buf, unsigned int len, struct timespec *delay);
 bool fmt_suspend(struct client_closure *closure, const char *signame, struct timespec *delay);
 bool fmt_winsize(struct client_closure *closure, unsigned int lines, unsigned int cols, struct timespec *delay);
-int log_server_connect(struct sudoers_str_list *servers, struct timespec *timo);
+int log_server_connect(struct sudoers_str_list *servers, struct timespec *timo, struct sudoers_string **connected_server);
 void client_closure_free(struct client_closure *closure);
 
 #endif /* SUDOERS_IOLOG_CLIENT_H */


### PR DESCRIPTION
This PR implements hostname/IP validation in SSL certificates.

- On client side, the server certificate's SAN field (GEN_DNS, GEN_IPADD) or CN field is compared to the server's name/address
- On server side, if tls_checkpeer option is set in sudo_logsrvd.conf, the client's certificate's SAN/CN field is compared to the client's IP address. If the client cert contains a name, the validation process checks that the name resolves to the client's IP address or not.