### PR TITLE
Optional server cert check

### DIFF
--- a/examples/sudo_logsrvd.conf
+++ b/examples/sudo_logsrvd.conf
@@ -28,16 +28,26 @@
 # By default, server connections are not encrypted.
 #tls = true
 
+# If set, server certificate will be verified at server startup and
+# also connecting clients will perform server authentication by
+# verifying the server's certificate and identity.
+#tls_verify = true
+
+# Whether to verify client certificates for TLS connections.
+# By default client certs are not checked.
+#tls_checkpeer = false
+
 # Path to the certificate authority bundle file in PEM format.
+# Required if 'tls_verify' or 'tls_checkpeer' is set.
 #tls_cacert = /etc/ssl/sudo/cacert.pem
 
 # Path to the server's certificate file in PEM format.
 # Required for TLS connections.
 #tls_cert = /etc/ssl/sudo/logsrvd_cert.pem
 
-# Whether to verify client certificates for TLS connections.
-# By default client certs are not checked.
-#tls_checkpeer = false
+# Path to the server's private key file in PEM format.
+# Required for TLS connections.
+#tls_key = /etc/ssl/sudo/private/logsrvd_key.pem
 
 # TLS cipher list (see "CIPHER LIST FORMAT" in the openssl-ciphers manual).
 # NOTE that this setting is only effective if the negotiated protocol
@@ -52,10 +62,6 @@
 # Path to the Diffie-Hellman parameter file in PEM format.
 # If not set, the server will use the OpenSSL defaults.
 #tls_dhparams = /etc/ssl/sudo/logsrvd_dhparams.pem
-
-# Path to the server's private key file in PEM format.
-# Required for TLS connections.
-#tls_key = /etc/ssl/sudo/private/logsrvd_key.pem
 
 [iolog]
 # The top-level directory to use when constructing the path name for the

--- a/include/log_server.pb-c.h
+++ b/include/log_server.pb-c.h
@@ -412,7 +412,7 @@ struct  _ServerHello
   /*
    * true if client auth is required with signed cert 
    */
-  protobuf_c_boolean tls_checkpeer;
+  protobuf_c_boolean tls_reqcert;
 };
 #define SERVER_HELLO__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&server_hello__descriptor) \

--- a/include/log_server.pb-c.h
+++ b/include/log_server.pb-c.h
@@ -410,13 +410,17 @@ struct  _ServerHello
    */
   protobuf_c_boolean tls;
   /*
+   * true if server auth has to be performed 
+   */
+  protobuf_c_boolean tls_server_auth;
+  /*
    * true if client auth is required with signed cert 
    */
   protobuf_c_boolean tls_reqcert;
 };
 #define SERVER_HELLO__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&server_hello__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL, 0, 0 }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL, 0, 0, 0 }
 
 
 /* ClientMessage methods */

--- a/lib/logsrv/log_server.pb-c.c
+++ b/lib/logsrv/log_server.pb-c.c
@@ -1578,7 +1578,7 @@ const ProtobufCMessageDescriptor server_message__descriptor =
   (ProtobufCMessageInit) server_message__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor server_hello__field_descriptors[5] =
+static const ProtobufCFieldDescriptor server_hello__field_descriptors[6] =
 {
   {
     "server_id",
@@ -1629,8 +1629,20 @@ static const ProtobufCFieldDescriptor server_hello__field_descriptors[5] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "tls_reqcert",
+    "tls_server_auth",
     5,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_BOOL,
+    0,   /* quantifier_offset */
+    offsetof(ServerHello, tls_server_auth),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "tls_reqcert",
+    6,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
@@ -1646,12 +1658,13 @@ static const unsigned server_hello__field_indices_by_name[] = {
   0,   /* field[0] = server_id */
   2,   /* field[2] = servers */
   3,   /* field[3] = tls */
-  4,   /* field[4] = tls_reqcert */
+  5,   /* field[5] = tls_reqcert */
+  4,   /* field[4] = tls_server_auth */
 };
 static const ProtobufCIntRange server_hello__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 5 }
+  { 0, 6 }
 };
 const ProtobufCMessageDescriptor server_hello__descriptor =
 {
@@ -1661,7 +1674,7 @@ const ProtobufCMessageDescriptor server_hello__descriptor =
   "ServerHello",
   "",
   sizeof(ServerHello),
-  5,
+  6,
   server_hello__field_descriptors,
   server_hello__field_indices_by_name,
   1,  server_hello__number_ranges,

--- a/lib/logsrv/log_server.pb-c.c
+++ b/lib/logsrv/log_server.pb-c.c
@@ -1629,12 +1629,12 @@ static const ProtobufCFieldDescriptor server_hello__field_descriptors[5] =
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "tls_checkpeer",
+    "tls_reqcert",
     5,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
-    offsetof(ServerHello, tls_checkpeer),
+    offsetof(ServerHello, tls_reqcert),
     NULL,
     NULL,
     0,             /* flags */
@@ -1646,7 +1646,7 @@ static const unsigned server_hello__field_indices_by_name[] = {
   0,   /* field[0] = server_id */
   2,   /* field[2] = servers */
   3,   /* field[3] = tls */
-  4,   /* field[4] = tls_checkpeer */
+  4,   /* field[4] = tls_reqcert */
 };
 static const ProtobufCIntRange server_hello__number_ranges[1 + 1] =
 {

--- a/lib/logsrv/log_server.proto
+++ b/lib/logsrv/log_server.proto
@@ -126,5 +126,5 @@ message ServerHello {
   string redirect = 2;		/* optional redirect if busy */
   repeated string servers = 3;	/* optional list of known servers */
   bool tls = 4;             /* true if server uses tls protocol */
-  bool tls_checkpeer = 5;   /* true if client auth is required with signed cert */
+  bool tls_reqcert = 5;   /* true if client auth is required with signed cert */
 }

--- a/lib/logsrv/log_server.proto
+++ b/lib/logsrv/log_server.proto
@@ -126,5 +126,6 @@ message ServerHello {
   string redirect = 2;		/* optional redirect if busy */
   repeated string servers = 3;	/* optional list of known servers */
   bool tls = 4;             /* true if server uses tls protocol */
-  bool tls_reqcert = 5;   /* true if client auth is required with signed cert */
+  bool tls_server_auth = 5; /* true if server auth has to be performed */
+  bool tls_reqcert = 6;     /* true if client auth is required with signed cert */
 }

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -178,10 +178,10 @@ fmt_hello_message(struct connection_buffer *buf)
     hello.server_id = (char *)server_id;
 #if defined(HAVE_OPENSSL)
     hello.tls = logsrvd_conf_get_tls_opt();
-    hello.tls_checkpeer = logsrvd_get_tls_config()->check_peer;
+    hello.tls_reqcert = logsrvd_get_tls_config()->check_peer;
 #else
     hello.tls = false;
-    hello.tls_checkpeer = false;
+    hello.tls_reqcert = false;
 #endif
     msg.hello = &hello;
     msg.type_case = SERVER_MESSAGE__TYPE_HELLO;

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -136,6 +136,7 @@ struct logsrvd_tls_config {
     char *dhparams_path;
     char *ciphers_v12;
     char *ciphers_v13;
+    bool verify;
     bool check_peer;
 };
 

--- a/logsrvd/logsrvd_conf.c
+++ b/logsrvd/logsrvd_conf.c
@@ -527,6 +527,19 @@ cb_tls_ciphers13(struct logsrvd_config *config, const char *str)
 }
 
 static bool
+cb_tls_verify(struct logsrvd_config *config, const char *str)
+{
+    int val;
+    debug_decl(cb_tls_verify, SUDO_DEBUG_UTIL);
+
+    if ((val = sudo_strtobool(str)) == -1)
+	debug_return_bool(false);
+
+    config->server.tls_config.verify = val;
+    debug_return_bool(true);
+}
+
+static bool
 cb_tls_checkpeer(struct logsrvd_config *config, const char *str)
 {
     int val;
@@ -706,6 +719,7 @@ static struct logsrvd_config_entry server_conf_entries[] = {
     { "tls_ciphers_v12", cb_tls_ciphers12 },
     { "tls_ciphers_v13", cb_tls_ciphers13 },
     { "tls_checkpeer", cb_tls_checkpeer },
+    { "tls_verify", cb_tls_verify },
 #endif
     { NULL }
 };
@@ -882,6 +896,8 @@ logsrvd_conf_alloc(void)
 #if defined(HAVE_OPENSSL)
     config->server.tls_config.cacert_path = strdup(DEFAULT_CA_CERT_PATH);
     config->server.tls_config.cert_path = strdup(DEFAULT_SERVER_CERT_PATH);
+    config->server.tls_config.verify = true;
+    config->server.tls_config.check_peer = false;
 #endif
 
     /* I/O log defaults */

--- a/logsrvd/sendlog.c
+++ b/logsrvd/sendlog.c
@@ -76,7 +76,7 @@ static char *iolog_dir;
 
 #if defined(HAVE_OPENSSL)
 static bool tls = false;
-static bool tls_checkpeer = false;
+static bool tls_reqcert = false;
 static SSL_CTX *ssl_ctx = NULL;
 static SSL *ssl = NULL;
 const char *ca_bundle = NULL;
@@ -301,7 +301,7 @@ do_tls_handshake(struct client_closure *closure)
         sudo_warnx("%s", U_("CA bundle file was not specified"));
         goto bad;
     }
-    if (tls_checkpeer && (cert == NULL)) {
+    if (tls_reqcert && (cert == NULL)) {
         sudo_warnx("%s", U_("Client certificate was not specified"));
         goto bad;
     }
@@ -982,10 +982,10 @@ handle_server_hello(ServerHello *msg, struct client_closure *closure)
 
 #if defined(HAVE_OPENSSL)
     tls = msg->tls;
-    tls_checkpeer = msg->tls_checkpeer;
+    tls_reqcert = msg->tls_reqcert;
     if (tls) {
         printf("Requested protocol: TLS\n");
-        if (tls_checkpeer)
+        if (tls_reqcert)
             printf("Client auth is required with signed certificate\n");
     }
 #endif

--- a/plugins/sudoers/iolog_client.c
+++ b/plugins/sudoers/iolog_client.c
@@ -281,7 +281,7 @@ verify_peer_identity(int preverify_ok, X509_STORE_CTX *ctx)
 }
 
 static bool
-tls_init(struct client_closure *closure, bool peer_auth)
+tls_init(struct client_closure *closure, bool cert_required)
 {
     debug_decl(tls_init, SUDOERS_DEBUG_PLUGIN);
 
@@ -326,7 +326,7 @@ tls_init(struct client_closure *closure, bool peer_auth)
     SSL_CTX_set_verify(closure->ssl_ctx, SSL_VERIFY_PEER, verify_peer_identity);
 
     /* if the server requests client authentication with signed certificate */
-    if (peer_auth) {
+    if (cert_required) {
         /* if no certificate file is set in sudoers */
         if (closure->log_details->cert_file == NULL) {
             sudo_warnx(U_("Signed certificate file is not set in sudoers"));
@@ -1057,7 +1057,7 @@ handle_server_hello(ServerHello *msg, struct client_closure *closure)
 #if defined(HAVE_OPENSSL)
     /* if server requested TLS */
     if (msg->tls) {
-        if (!tls_init(closure, msg->tls_checkpeer)) {
+        if (!tls_init(closure, msg->tls_reqcert)) {
             sudo_warnx(U_("TLS initialization was unsuccessful"));
             debug_return_bool(false);
         }


### PR DESCRIPTION
This PR handles the use case when CA certs are note distributed to clients to authenticate the server.
A new configuration option (tls_verify) has been added to sudo_logsrvd.conf.

If tls_verify is set:
- Server performs a certificate verification on its own certificate at startup
- Client will perform server authentication (verify server's cert) during tls handshake.

If tls_verify is not set
- Server skips the verification of its own certificate
- Client won't authenticate the server, therefore no need to set ca_bundle file in /etc/sudoers

The tls_checkpeer configuration option is independent from tls_verify. If both set to false, tls_cacert option is not required to set in sudo_logsrvd.conf, since both server authentication and client authentication are turned off.