### PR TITLE
Make each python plugin run in separate interpreters

### DIFF
--- a/plugins/python/pyhelpers.c
+++ b/plugins/python/pyhelpers.c
@@ -116,13 +116,19 @@ py_create_traceback_string(PyObject *py_traceback)
 
     char* traceback = NULL;
 
-    if (py_ctx.py_traceback_module != NULL) {
-        PyObject *py_traceback_str_list = PyObject_CallMethod(py_ctx.py_traceback_module, "format_tb", "(O)", py_traceback);
+
+    PyObject *py_traceback_module = PyImport_ImportModule("traceback");
+    if (py_traceback_module == NULL) {
+        PyErr_Clear(); // do not care, we just won't show backtrace
+    } else {
+        PyObject *py_traceback_str_list = PyObject_CallMethod(py_traceback_module, "format_tb", "(O)", py_traceback);
 
         if (py_traceback_str_list != NULL) {
             traceback = py_join_str_list(py_traceback_str_list, "");
             Py_DECREF(py_traceback_str_list);
         }
+
+        Py_CLEAR(py_traceback_module);
     }
 
     debug_return_str(traceback ? traceback : strdup(""));

--- a/plugins/python/pyhelpers.h
+++ b/plugins/python/pyhelpers.h
@@ -43,8 +43,7 @@ struct PythonContext
     sudo_printf_t sudo_log;
     sudo_conv_t sudo_conv;
     int open_plugin_count;
-
-    PyObject *py_traceback_module;
+    PyThreadState *py_main_interpreter;
 };
 
 extern struct PythonContext py_ctx;

--- a/plugins/python/python_plugin_common.h
+++ b/plugins/python/python_plugin_common.h
@@ -22,6 +22,7 @@
 #include "pyhelpers.h"
 
 struct PluginContext {
+    PyThreadState *py_interpreter;
     PyObject *py_module;
     PyObject *py_class;
     PyObject *py_instance;

--- a/plugins/python/python_plugin_group.c
+++ b/plugins/python/python_plugin_group.c
@@ -83,6 +83,7 @@ void
 python_plugin_group_cleanup(void)
 {
     debug_decl(python_plugin_group_cleanup, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
     python_plugin_deinit(&plugin_ctx);
 }
 
@@ -90,6 +91,8 @@ int
 python_plugin_group_query(const char *user, const char *group, const struct passwd *pwd)
 {
     debug_decl(python_plugin_group_query, PYTHON_DEBUG_CALLBACKS);
+
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
 
     PyObject *py_pwd = py_from_passwd(pwd);
     if (py_pwd == NULL) {

--- a/plugins/python/python_plugin_io.c
+++ b/plugins/python/python_plugin_io.c
@@ -134,6 +134,8 @@ python_plugin_io_show_version(struct IOPluginContext *io_ctx, int verbose)
 {
     debug_decl(python_plugin_io_show_version, PYTHON_DEBUG_CALLBACKS);
 
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
+
     if (verbose) {
         py_sudo_log(SUDO_CONV_INFO_MSG, "Python io plugin API version %d.%d\n", "%d.%d",
                     SUDO_API_VERSION_GET_MAJOR(PY_IO_PLUGIN_VERSION),
@@ -147,6 +149,7 @@ int
 python_plugin_io_log_ttyin(struct IOPluginContext *io_ctx, const char *buf, unsigned int len)
 {
     debug_decl(python_plugin_io_log_ttyin, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_ttyin),
                                      Py_BuildValue("(s#)", buf, len)));
 }
@@ -155,6 +158,7 @@ int
 python_plugin_io_log_ttyout(struct IOPluginContext *io_ctx, const char *buf, unsigned int len)
 {
     debug_decl(python_plugin_io_log_ttyout, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_ttyout),
                                      Py_BuildValue("(s#)", buf, len)));
 }
@@ -163,6 +167,7 @@ int
 python_plugin_io_log_stdin(struct IOPluginContext *io_ctx, const char *buf, unsigned int len)
 {
     debug_decl(python_plugin_io_log_stdin, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_stdin),
                                                Py_BuildValue("(s#)", buf, len)));
 }
@@ -171,6 +176,7 @@ int
 python_plugin_io_log_stdout(struct IOPluginContext *io_ctx, const char *buf, unsigned int len)
 {
     debug_decl(python_plugin_io_log_stdout, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_stdout),
                                                Py_BuildValue("(s#)", buf, len)));
 }
@@ -179,6 +185,7 @@ int
 python_plugin_io_log_stderr(struct IOPluginContext *io_ctx, const char *buf, unsigned int len)
 {
     debug_decl(python_plugin_io_log_stderr, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_stderr),
                                                Py_BuildValue("(s#)", buf, len)));
 }
@@ -187,6 +194,7 @@ int
 python_plugin_io_change_winsize(struct IOPluginContext *io_ctx, unsigned int line, unsigned int cols)
 {
     debug_decl(python_plugin_io_change_winsize, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(change_winsize),
                                                Py_BuildValue("(ii)", line, cols)));
 }
@@ -195,6 +203,7 @@ int
 python_plugin_io_log_suspend(struct IOPluginContext *io_ctx, int signo)
 {
     debug_decl(python_plugin_io_log_suspend, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
     debug_return_int(python_plugin_api_rc_call(BASE_CTX(io_ctx), CALLBACK_PYNAME(log_suspend),
                                      Py_BuildValue("(i)", signo)));
 }

--- a/plugins/python/python_plugin_policy.c
+++ b/plugins/python/python_plugin_policy.c
@@ -96,6 +96,8 @@ python_plugin_policy_check(int argc, char * const argv[],
     debug_decl(python_plugin_policy_check, PYTHON_DEBUG_CALLBACKS);
     int rc = SUDO_RC_ERROR;
 
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
+
     *command_info_out = *argv_out = *user_env_out = NULL;
 
     PyObject *py_argv = py_str_array_to_tuple_with_count(argc, argv);
@@ -169,6 +171,8 @@ python_plugin_policy_list(int argc, char * const argv[], int verbose, const char
 {
     debug_decl(python_plugin_policy_list, PYTHON_DEBUG_CALLBACKS);
 
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
+
     PyObject *py_argv = py_str_array_to_tuple_with_count(argc, argv);
     if (py_argv == NULL) {
         sudo_debug_printf(SUDO_DEBUG_ERROR, "%s: Failed to create argv argument for the python call\n", __PRETTY_FUNCTION__);
@@ -187,6 +191,8 @@ python_plugin_policy_version(int verbose)
 {
     debug_decl(python_plugin_policy_version, PYTHON_DEBUG_CALLBACKS);
 
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
+
     if (verbose) {
         py_sudo_log(SUDO_CONV_INFO_MSG, "Python policy plugin API version %d.%d\n", "%d.%d",
                     SUDO_API_VERSION_GET_MAJOR(PY_POLICY_PLUGIN_VERSION),
@@ -200,6 +206,7 @@ int
 python_plugin_policy_validate(void)
 {
     debug_decl(python_plugin_policy_validate, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
     debug_return_int(python_plugin_api_rc_call(&plugin_ctx, CALLBACK_PYNAME(validate), NULL));
 }
 
@@ -207,6 +214,7 @@ void
 python_plugin_policy_invalidate(int remove)
 {
     debug_decl(python_plugin_policy_invalidate, PYTHON_DEBUG_CALLBACKS);
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
     python_plugin_api_rc_call(&plugin_ctx, CALLBACK_PYNAME(invalidate),
                               Py_BuildValue("(i)", remove));
     debug_return;
@@ -217,6 +225,7 @@ python_plugin_policy_init_session(struct passwd *pwd, char **user_env[])
 {
     debug_decl(python_plugin_policy_init_session, PYTHON_DEBUG_CALLBACKS);
     int rc = SUDO_RC_ERROR;
+    PyThreadState_Swap(plugin_ctx.py_interpreter);
     PyObject *py_pwd = NULL, *py_user_env = NULL, *py_result = NULL;
 
     py_pwd = py_from_passwd(pwd);

--- a/plugins/python/regress/plugin_conflict.py
+++ b/plugins/python/regress/plugin_conflict.py
@@ -1,0 +1,11 @@
+import sudo
+
+import sys
+
+sys.path = []
+
+class ConflictPlugin(sudo.Plugin):
+    def __init__(self, plugin_options, **kwargs):
+        sudo.log_info("PATH before: {} (should be empty)".format(sys.path))
+        sys.path = [sudo.options_as_dict(plugin_options).get("Path")]
+        sudo.log_info("PATH set: {}".format(sys.path))

--- a/plugins/python/regress/testdata/check_python_plugins_do_not_affect_each_other.stdout
+++ b/plugins/python/regress/testdata/check_python_plugins_do_not_affect_each_other.stdout
@@ -1,0 +1,4 @@
+PATH before: [] (should be empty)
+PATH set: ['path_for_first_plugin']
+PATH before: [] (should be empty)
+PATH set: ['path_for_second_plugin']


### PR DESCRIPTION
If they are run in the same interpreter, they can affect each other's state.