### PR TITLE
plugins/sudo_python_module: Fix double free in sudo.options_as_dict function

### DIFF
--- a/plugins/python/sudo_python_module.c
+++ b/plugins/python/sudo_python_module.c
@@ -183,7 +183,6 @@ python_sudo_options_as_dict(PyObject *py_self, PyObject *py_args)
     }
 
 cleanup:
-    Py_CLEAR(py_config_tuple);
     Py_CLEAR(py_config_tuple_iterator);
     Py_CLEAR(py_config);
     Py_CLEAR(py_splitted);


### PR DESCRIPTION
PyArg_ParseTuple sets the py_config_tuple pointer, but it does not
increment the reference count, so by decrementing, we end up freeing
the argument passed in.