### PR TITLE
Makefile.in: fix install target for out of source build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ abs_top_srcdir = @abs_top_srcdir@
 top_builddir = @top_builddir@
 abs_top_builddir = @abs_top_builddir@
 devdir = @devdir@
-scriptdir = $(top_srcdir)/scripts
+scriptdir = $(abs_top_srcdir)/scripts
 
 # Installation paths for package building
 prefix = @prefix@


### PR DESCRIPTION
The scriptdir contained a path relative to where the target was started.
The scripts are called like "$scriptdir/script_name" which is fine with
relative path as well, until the current directory is not changed.
But things like
  cd $srcdir && $scriptdir/script_name
fails (if building in separate build directory).