### PR TITLE
No python interpreter deinit

### DIFF
--- a/plugins/python/pyhelpers.c
+++ b/plugins/python/pyhelpers.c
@@ -63,10 +63,7 @@ _sudo_printf_default(int msg_type, const char *fmt, ...)
 
 
 struct PythonContext py_ctx = {
-    &_sudo_printf_default,
-    NULL,
-    0,
-    NULL
+    .sudo_log = &_sudo_printf_default,
 };
 
 

--- a/plugins/python/pyhelpers.h
+++ b/plugins/python/pyhelpers.h
@@ -38,12 +38,15 @@ enum SudoPluginFunctionReturnCode {
     SUDO_RC_USAGE_ERROR = -2,
 };
 
+#define INTERPRETER_MAX 32
+
 struct PythonContext
 {
     sudo_printf_t sudo_log;
     sudo_conv_t sudo_conv;
-    int open_plugin_count;
     PyThreadState *py_main_interpreter;
+    size_t interpreter_count;
+    PyThreadState *py_subinterpreters[INTERPRETER_MAX];
 };
 
 extern struct PythonContext py_ctx;

--- a/plugins/python/python_plugin_common.c
+++ b/plugins/python/python_plugin_common.c
@@ -413,9 +413,10 @@ python_plugin_deinit(struct PluginContext *plugin_ctx)
             Py_Finalize();
         }
 
-        python_debug_deregister();
         py_ctx_reset();
     }
+
+    python_debug_deregister();
 
     debug_return;
 }

--- a/plugins/python/python_plugin_common.c
+++ b/plugins/python/python_plugin_common.c
@@ -30,6 +30,8 @@
 #include <limits.h>
 #include <string.h>
 
+static struct _inittab * python_inittab_copy = NULL;
+static size_t python_inittab_copy_len = 0;
 
 const char *
 _lookup_value(char * const keyvalues[], const char *key)
@@ -126,6 +128,41 @@ _python_plugin_new_interpreter(void)
     }
 
     debug_return_ptr(py_interpreter);
+}
+
+static int
+_save_inittab(void)
+{
+    debug_decl(_save_inittab, PYTHON_DEBUG_INTERNAL);
+    free(python_inittab_copy);  // just to be sure (it is always NULL)
+
+    for (python_inittab_copy_len = 0;
+         PyImport_Inittab[python_inittab_copy_len].name != NULL;
+         ++python_inittab_copy_len) {
+    }
+    ++python_inittab_copy_len;  // for the null mark
+
+    python_inittab_copy = malloc(sizeof(struct _inittab) * python_inittab_copy_len);
+    if (python_inittab_copy == NULL) {
+        debug_return_int(SUDO_RC_ERROR);
+    }
+
+    memcpy(python_inittab_copy, PyImport_Inittab, python_inittab_copy_len * sizeof(struct _inittab));
+    debug_return_int(SUDO_RC_OK);
+}
+
+static void
+_restore_inittab(void)
+{
+    debug_decl(_restore_inittab, PYTHON_DEBUG_INTERNAL);
+
+    if (python_inittab_copy != NULL)
+        memcpy(PyImport_Inittab, python_inittab_copy, python_inittab_copy_len * sizeof(struct _inittab));
+
+    free(python_inittab_copy);
+    python_inittab_copy = NULL;
+    python_inittab_copy_len = 0;
+    debug_return;
 }
 
 void
@@ -311,6 +348,9 @@ _python_plugin_register_plugin_in_py_ctx(void)
         Py_IgnoreEnvironmentFlag = 1;
         Py_IsolatedFlag = 1;
         Py_NoUserSiteDirectory = 1;
+
+        if (_save_inittab() != SUDO_RC_OK)
+            debug_return_int(SUDO_RC_ERROR);
 
         PyImport_AppendInittab("sudo", sudo_module_init);
         Py_InitializeEx(0);
@@ -580,6 +620,9 @@ python_plugin_unlink(void)
         if (Py_FinalizeEx() != 0) {
             sudo_debug_printf(SUDO_DEBUG_WARN, "Closing: failed to deinit python interpreter\n");
         }
+
+        // Restore inittab so "sudo" module does not remain there (as garbage)
+        _restore_inittab();
     }
     py_ctx_reset();
     debug_return;

--- a/plugins/python/regress/testdata/check_example_debugging_load@diag.log
+++ b/plugins/python/regress/testdata/check_example_debugging_load@diag.log
@@ -1,4 +1,3 @@
 importing module: SRC_DIR/example_debugging.py
 Extending python 'path' with 'SRC_DIR'
-Closing: 0 python plugins left open
-Closing: deinit python interpreter
+Deinit was called for a python plugin

--- a/plugins/python/regress/testhelpers.c
+++ b/plugins/python/regress/testhelpers.c
@@ -262,7 +262,7 @@ mock_python_datetime_now(const char *plugin_name, const char *date_str)
                    "import time\n"
                    "from unittest.mock import Mock\n"
                    "%s.datetime = Mock()\n"           // replace plugin's datetime
-                   "%s.datetime.now = lambda: datetime.fromtimestamp(time.mktime(time.strptime('%s', '%%Y-%%m-%%dT%%H:%%M:%%S')))\n",
+                   "%s.datetime.now = lambda: datetime.strptime('%s', '%%Y-%%m-%%dT%%H:%%M:%%S')\n",
              plugin_name, plugin_name, plugin_name, date_str);
     VERIFY_PTR_NE(cmd, NULL);
     VERIFY_INT(PyRun_SimpleString(cmd), 0);

--- a/plugins/python/sudo_python_debug.c
+++ b/plugins/python/sudo_python_debug.c
@@ -39,6 +39,7 @@
 
 
 static int python_debug_instance = SUDO_DEBUG_INSTANCE_INITIALIZER;
+static unsigned int python_debug_refcnt;
 
 static const char *const python_subsystem_names[] = {
     "py_calls",  // logs c  -> py calls
@@ -79,20 +80,14 @@ bool
 python_debug_register(const char *program,
     struct sudo_conf_debug_file_list *debug_files)
 {
+    int instance = python_debug_instance;
     struct sudo_debug_file *debug_file, *debug_next;
-
-    /* Already initialized? */
-    if (python_debug_instance != SUDO_DEBUG_INSTANCE_INITIALIZER) {
-        sudo_debug_set_active_instance(python_debug_instance);
-    }
 
     /* Setup debugging if indicated. */
     if (debug_files != NULL && !TAILQ_EMPTY(debug_files)) {
         if (program != NULL) {
-            python_debug_instance = sudo_debug_register(program,
-                python_subsystem_names, (unsigned int *)python_subsystem_ids, debug_files);
-            if (python_debug_instance == SUDO_DEBUG_INSTANCE_ERROR)
-                return false;
+            instance = sudo_debug_register(program, python_subsystem_names,
+                (unsigned int *)python_subsystem_ids, debug_files);
         }
         TAILQ_FOREACH_SAFE(debug_file, debug_files, entries, debug_next) {
             TAILQ_REMOVE(debug_files, debug_file, entries);
@@ -101,6 +96,21 @@ python_debug_register(const char *program,
             free(debug_file);
         }
     }
+
+    switch (instance) {
+    case SUDO_DEBUG_INSTANCE_ERROR:
+        return false;
+    case SUDO_DEBUG_INSTANCE_INITIALIZER:
+        /* Nothing to do */
+        break;
+    default:
+        /* New debug instance or additional reference on existing one. */
+        python_debug_instance = instance;
+        sudo_debug_set_active_instance(python_debug_instance);
+        python_debug_refcnt++;
+        break;
+    }
+
     return true;
 }
 
@@ -112,9 +122,11 @@ python_debug_deregister(void)
 {
     debug_decl(python_debug_deregister, PYTHON_DEBUG_INTERNAL);
 
-    if (python_debug_instance != SUDO_DEBUG_INSTANCE_INITIALIZER) {
+    if (python_debug_refcnt != 0) {
         sudo_debug_exit(__func__, __FILE__, __LINE__, sudo_debug_subsys);
-        sudo_debug_deregister(python_debug_instance);
-        python_debug_instance = SUDO_DEBUG_INSTANCE_INITIALIZER;
+        if (--python_debug_refcnt == 0) {
+            if (sudo_debug_deregister(python_debug_instance) < 1)
+                python_debug_instance = SUDO_DEBUG_INSTANCE_INITIALIZER;
+        }
     }
 }

--- a/plugins/python/sudo_python_module.c
+++ b/plugins/python/sudo_python_module.c
@@ -23,9 +23,6 @@
 
 #include "sudo_python_module.h"
 
-CPYCHECKER_RETURNS_BORROWED_REF
-PyAPI_FUNC(PyObject *) PyStructSequence_GetItem(PyObject *, Py_ssize_t);
-
 #define EXC_VAR(exception_name) sudo_exc_ ## exception_name
 #define TYPE_VAR(type_name) &sudo_type_ ## type_name
 


### PR DESCRIPTION
We only deinit the python interpreters when sudo unlinks our plugin so we can avoid issues with python modules which do not support the interpreter reload use case (eg. datetime.strptime).
Also restores python inittab, so the "sudo" module entry (with the module's init function) can not remain there as garbage (noticed this as a test crash on OpenBSD).