### PR TITLE
Python display version improve

### DIFF
--- a/doc/sudo_plugin_python.man.in
+++ b/doc/sudo_plugin_python.man.in
@@ -47,6 +47,9 @@ I/O plugin
 Audit plugin
 .TP 3n
 \fB\(bu\fR
+Approval plugin
+.TP 3n
+\fB\(bu\fR
 Group provider plugin
 .RE
 .PD

--- a/doc/sudo_plugin_python.mdoc.in
+++ b/doc/sudo_plugin_python.mdoc.in
@@ -40,6 +40,8 @@ I/O plugin
 .It
 Audit plugin
 .It
+Approval plugin
+.It
 Group provider plugin
 .El
 .Pp

--- a/plugins/python/python_plugin_approval.c
+++ b/plugins/python/python_plugin_approval.c
@@ -38,12 +38,6 @@ struct ApprovalPluginContext
 // This also verifies compile time that the name matches the sudo plugin API.
 #define CALLBACK_PYNAME(func_name) ((void)CALLBACK_PLUGINFUNC(func_name), #func_name)
 
-#define MARK_CALLBACK_OPTIONAL(function_name) \
-    do { \
-        python_plugin_mark_callback_optional(plugin_ctx, CALLBACK_PYNAME(function_name), \
-            (void **)&CALLBACK_PLUGINFUNC(function_name)); \
-    } while(0)
-
 
 static int
 python_plugin_approval_open(struct ApprovalPluginContext *approval_ctx,
@@ -92,9 +86,6 @@ python_plugin_approval_open(struct ApprovalPluginContext *approval_ctx,
     if (rc != SUDO_RC_OK) {
         debug_return_int(rc);
     }
-
-    // skip plugin callbacks which are not mandatory
-    MARK_CALLBACK_OPTIONAL(show_version);
 
     debug_return_int(rc);
 }

--- a/plugins/python/python_plugin_approval.c
+++ b/plugins/python/python_plugin_approval.c
@@ -141,14 +141,8 @@ python_plugin_approval_show_version(struct ApprovalPluginContext *approval_ctx, 
     struct PluginContext *plugin_ctx = BASE_CTX(approval_ctx);
     PyThreadState_Swap(plugin_ctx->py_interpreter);
 
-    if (verbose) {
-        py_sudo_log(SUDO_CONV_INFO_MSG, "Python approval plugin API version %d.%d\n",
-                    SUDO_API_VERSION_GET_MAJOR(PY_APPROVAL_PLUGIN_VERSION),
-                    SUDO_API_VERSION_GET_MINOR(PY_APPROVAL_PLUGIN_VERSION));
-    }
-
     debug_return_int(python_plugin_show_version(plugin_ctx,
-        CALLBACK_PYNAME(show_version), verbose));
+        CALLBACK_PYNAME(show_version), verbose, PY_APPROVAL_PLUGIN_VERSION, "approval"));
 }
 
 __dso_public struct approval_plugin python_approval;

--- a/plugins/python/python_plugin_audit.c
+++ b/plugins/python/python_plugin_audit.c
@@ -103,7 +103,6 @@ python_plugin_audit_open(struct AuditPluginContext *audit_ctx,
     MARK_CALLBACK_OPTIONAL(accept);
     MARK_CALLBACK_OPTIONAL(reject);
     MARK_CALLBACK_OPTIONAL(error);
-    MARK_CALLBACK_OPTIONAL(show_version);
 
     plugin_ctx->call_close = 1;
     rc = _call_plugin_open(audit_ctx, submit_optind, submit_argv);
@@ -230,14 +229,8 @@ python_plugin_audit_show_version(struct AuditPluginContext *audit_ctx, int verbo
     struct PluginContext *plugin_ctx = BASE_CTX(audit_ctx);
     PyThreadState_Swap(plugin_ctx->py_interpreter);
 
-    if (verbose) {
-        py_sudo_log(SUDO_CONV_INFO_MSG, "Python audit plugin API version %d.%d\n",
-                    SUDO_API_VERSION_GET_MAJOR(PY_AUDIT_PLUGIN_VERSION),
-                    SUDO_API_VERSION_GET_MINOR(PY_AUDIT_PLUGIN_VERSION));
-    }
-
     debug_return_int(python_plugin_show_version(plugin_ctx,
-        CALLBACK_PYNAME(show_version), verbose));
+        CALLBACK_PYNAME(show_version), verbose, PY_AUDIT_PLUGIN_VERSION, "audit"));
 }
 
 __dso_public struct audit_plugin python_audit;

--- a/plugins/python/python_plugin_common.c
+++ b/plugins/python/python_plugin_common.c
@@ -531,8 +531,13 @@ python_plugin_show_version(struct PluginContext *plugin_ctx, const char *python_
 {
     debug_decl(python_plugin_show_version, PYTHON_DEBUG_CALLBACKS);
 
-    debug_return_int(python_plugin_api_rc_call(plugin_ctx, python_callback_name,
-                                               Py_BuildValue("(i)", is_verbose)));
+    int rc = SUDO_RC_OK;
+    if (PyObject_HasAttrString(plugin_ctx->py_instance, python_callback_name)) {
+        rc = python_plugin_api_rc_call(plugin_ctx, python_callback_name,
+                                       Py_BuildValue("(i)", is_verbose));
+    }
+
+    debug_return_int(rc);
 }
 
 void

--- a/plugins/python/python_plugin_common.h
+++ b/plugins/python/python_plugin_common.h
@@ -28,6 +28,7 @@ struct PluginContext {
     PyObject *py_instance;
     int call_close;
     unsigned int sudo_api_version;
+    char *plugin_path;
 
     // We use this to let the error string live until sudo and the audit plugins
     // are using it.
@@ -50,7 +51,7 @@ int python_plugin_construct(struct PluginContext *plugin_ctx, unsigned int versi
 void python_plugin_deinit(struct PluginContext *plugin_ctx);
 
 int python_plugin_show_version(struct PluginContext *plugin_ctx,
-                               const char *python_callback_name, int isVerbose);
+                               const char *python_callback_name, int isVerbose, unsigned int plugin_api_version, const char *plugin_api_name);
 
 CPYCHECKER_STEALS_REFERENCE_TO_ARG(3)
 void python_plugin_close(struct PluginContext *plugin_ctx, const char *callback_name,

--- a/plugins/python/python_plugin_io.c
+++ b/plugins/python/python_plugin_io.c
@@ -109,7 +109,6 @@ python_plugin_io_open(struct IOPluginContext *io_ctx,
     }
 
     // skip plugin callbacks which are not mandatory
-    MARK_CALLBACK_OPTIONAL(show_version);
     MARK_CALLBACK_OPTIONAL(log_ttyin);
     MARK_CALLBACK_OPTIONAL(log_ttyout);
     MARK_CALLBACK_OPTIONAL(log_stdin);
@@ -142,13 +141,8 @@ python_plugin_io_show_version(struct IOPluginContext *io_ctx, int verbose)
 
     PyThreadState_Swap(BASE_CTX(io_ctx)->py_interpreter);
 
-    if (verbose) {
-        py_sudo_log(SUDO_CONV_INFO_MSG, "Python io plugin API version %d.%d\n",
-                    SUDO_API_VERSION_GET_MAJOR(PY_IO_PLUGIN_VERSION),
-                    SUDO_API_VERSION_GET_MINOR(PY_IO_PLUGIN_VERSION));
-    }
-
-    debug_return_int(python_plugin_show_version(BASE_CTX(io_ctx), CALLBACK_PYNAME(show_version), verbose));
+    debug_return_int(python_plugin_show_version(BASE_CTX(io_ctx), CALLBACK_PYNAME(show_version),
+                                                verbose, PY_IO_PLUGIN_VERSION, "io"));
 }
 
 int

--- a/plugins/python/python_plugin_policy.c
+++ b/plugins/python/python_plugin_policy.c
@@ -73,7 +73,6 @@ python_plugin_policy_open(unsigned int version, sudo_conv_t conversation,
     }
 
     // skip plugin callbacks which are not mandatory
-    MARK_CALLBACK_OPTIONAL(show_version);
     MARK_CALLBACK_OPTIONAL(list);
     MARK_CALLBACK_OPTIONAL(validate);
     MARK_CALLBACK_OPTIONAL(invalidate);
@@ -200,13 +199,8 @@ python_plugin_policy_version(int verbose)
 
     PyThreadState_Swap(plugin_ctx.py_interpreter);
 
-    if (verbose) {
-        py_sudo_log(SUDO_CONV_INFO_MSG, "Python policy plugin API version %d.%d\n",
-                    SUDO_API_VERSION_GET_MAJOR(PY_POLICY_PLUGIN_VERSION),
-                    SUDO_API_VERSION_GET_MINOR(PY_POLICY_PLUGIN_VERSION));
-    }
-
-    debug_return_int(python_plugin_show_version(&plugin_ctx, CALLBACK_PYNAME(show_version), verbose));
+    debug_return_int(python_plugin_show_version(&plugin_ctx, CALLBACK_PYNAME(show_version),
+                                                verbose, PY_POLICY_PLUGIN_VERSION, "policy"));
 }
 
 int

--- a/plugins/python/regress/check_python_examples.c
+++ b/plugins/python/regress/check_python_examples.c
@@ -175,7 +175,8 @@ check_example_io_plugin_version_display(int is_verbose)
     if (is_verbose) {
         // Note: the exact python version is environment dependant
         VERIFY_STR_CONTAINS(data.stdout_str, "Python interpreter version:");
-        VERIFY_STR_CONTAINS(data.stdout_str, "Python io plugin API version");
+        *strstr(data.stdout_str, "Python interpreter version:") = '\0';
+        VERIFY_STDOUT(expected_path("check_example_io_plugin_version_display_full.stdout"));
     } else {
         VERIFY_STDOUT(expected_path("check_example_io_plugin_version_display.stdout"));
     }
@@ -687,7 +688,8 @@ check_example_policy_plugin_version_display(int is_verbose)
     if (is_verbose) {
         // Note: the exact python version is environment dependant
         VERIFY_STR_CONTAINS(data.stdout_str, "Python interpreter version:");
-        VERIFY_STR_CONTAINS(data.stdout_str, "Python policy plugin API version");
+        *strstr(data.stdout_str, "Python interpreter version:") = '\0';
+        VERIFY_STDOUT(expected_path("check_example_policy_plugin_version_display_full.stdout"));
     } else {
         VERIFY_STDOUT(expected_path("check_example_policy_plugin_version_display.stdout"));
     }
@@ -928,7 +930,10 @@ check_policy_plugin_callbacks_are_optional(void)
     VERIFY_PTR(python_policy->invalidate, NULL);
     VERIFY_PTR_NE(python_policy->check_policy, NULL); // (not optional)
     VERIFY_PTR(python_policy->init_session, NULL);
-    VERIFY_PTR(python_policy->show_version, NULL);
+
+    // show_version always displays the plugin, but it is optional in the python layer
+    VERIFY_PTR_NE(python_policy->show_version, NULL);
+    VERIFY_INT(python_policy->show_version(1), SUDO_RC_OK);
 
     python_policy->close(0, 0);
     return true;
@@ -1014,8 +1019,11 @@ check_io_plugin_callbacks_are_optional(void)
     VERIFY_PTR(python_io->log_stderr, NULL);
     VERIFY_PTR(python_io->log_ttyin, NULL);
     VERIFY_PTR(python_io->log_ttyout, NULL);
-    VERIFY_PTR(python_io->show_version, NULL);
     VERIFY_PTR(python_io->change_winsize, NULL);
+
+    // show_version always displays the plugin, but it is optional in the python layer
+    VERIFY_PTR_NE(python_io->show_version, NULL);
+    VERIFY_INT(python_io->show_version(1), SUDO_RC_OK);
 
     python_io->close(0, 0);
     return true;
@@ -1261,7 +1269,10 @@ check_audit_plugin_callbacks_are_optional(void)
     VERIFY_PTR(python_audit->accept, NULL);
     VERIFY_PTR(python_audit->reject, NULL);
     VERIFY_PTR(python_audit->error, NULL);
-    VERIFY_PTR(python_audit->show_version, NULL);
+
+    // show_version always displays the plugin, but it is optional in the python layer
+    VERIFY_PTR_NE(python_audit->show_version, NULL);
+    VERIFY_INT(python_audit->show_version(1), SUDO_RC_OK);
 
     python_audit->close(SUDO_PLUGIN_NO_STATUS, 0);
     return true;

--- a/plugins/python/regress/testdata/check_example_audit_plugin_version_display.stdout
+++ b/plugins/python/regress/testdata/check_example_audit_plugin_version_display.stdout
@@ -1,6 +1,6 @@
 (AUDIT)  -- Started by user root (0) -- 
 Python Example Audit Plugin
-Python audit plugin API version 1.0
+Python audit plugin (API 1.0): SudoAuditPlugin (loaded from 'SRC_DIR/example_audit_plugin.py')
 Python Example Audit Plugin (version=1.0)
 (AUDIT)  Sudo has run into an error: 222
 (AUDIT)  -- Finished --

--- a/plugins/python/regress/testdata/check_example_debugging_py_calls@info.log
+++ b/plugins/python/regress/testdata/check_example_debugging_py_calls@info.log
@@ -1,6 +1,5 @@
 DebugDemoPlugin.__init__ was called with arguments: () {'version': '1.0', 'settings': ('debug_flags=/tmp/sudo_check_python_exampleXXXXXX/debug.log py_calls@info', 'plugin_path=python_plugin.so'), 'user_env': (), 'user_info': (), 'plugin_options': ('ModulePath=SRC_DIR/example_debugging.py', 'ClassName=DebugDemoPlugin')}
 DebugDemoPlugin.__init__ returned result: <example_debugging.DebugDemoPlugin object>
-DebugDemoPlugin function 'show_version' is not implemented
 DebugDemoPlugin function 'log_ttyin' is not implemented
 DebugDemoPlugin function 'log_ttyout' is not implemented
 DebugDemoPlugin function 'log_stdin' is not implemented

--- a/plugins/python/regress/testdata/check_example_io_plugin_version_display_full.stdout
+++ b/plugins/python/regress/testdata/check_example_io_plugin_version_display_full.stdout
@@ -1,0 +1,3 @@
+Example sudo python plugin will log to /tmp/sudo_check_python_exampleXXXXXX/sudo.log
+Python io plugin (API 1.0): SudoIOPlugin (loaded from 'SRC_DIR/example_io_plugin.py')
+Python Example IO Plugin version: 1.0

--- a/plugins/python/regress/testdata/check_example_policy_plugin_version_display_full.stdout
+++ b/plugins/python/regress/testdata/check_example_policy_plugin_version_display_full.stdout
@@ -1,0 +1,2 @@
+Python policy plugin (API 1.0): SudoPolicyPlugin (loaded from 'SRC_DIR/example_policy_plugin.py')
+Python Example Policy Plugin version: 1.0

--- a/plugins/python/regress/testdata/check_multiple_approval_plugin_and_arguments.stdout
+++ b/plugins/python/regress/testdata/check_multiple_approval_plugin_and_arguments.stdout
@@ -59,7 +59,7 @@
     "_id": "(APPROVAL 2)"
 }
 (APPROVAL 1) Show version was called with arguments: (0,)
-Python approval plugin API version 1.0
+Python approval plugin (API 1.0): ApprovalTestPlugin (loaded from 'SRC_DIR/regress/plugin_approval_test.py')
 (APPROVAL 2) Show version was called with arguments: (1,)
 (APPROVAL 1) Check was called with arguments: (('CMDINFO1=value1', 'CMDINFO2=VALUE2'), ('whoami', '--help'), ('USER_ENV1=VALUE1', 'USER_ENV2=value2'))
 (APPROVAL 2) Check was called with arguments: (('CMDINFO1=value1', 'CMDINFO2=VALUE2'), ('whoami', '--help'), ('USER_ENV1=VALUE1', 'USER_ENV2=value2'))


### PR DESCRIPTION
Show version now displays the class and the path of the python plugin.
Also fixes the crash of "sudo -V" if a python approval plugin did not have a show_version function.