### PR TITLE
Use port 30343 for plaintext and port 30344 for TLS.

### DIFF
--- a/doc/sudo_logsrv.proto.man.in
+++ b/doc/sudo_logsrv.proto.man.in
@@ -16,7 +16,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.TH "SUDO_LOGSRV.PROTO" "@mansectform@" "April 20, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
+.TH "SUDO_LOGSRV.PROTO" "@mansectform@" "April 30, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
 .nh
 .if n .ad l
 .SH "NAME"
@@ -438,9 +438,6 @@ message ServerHello {
   string server_id = 1;
   string redirect = 2;
   repeated string servers = 3;
-  bool tls = 4;
-  bool tls_server_auth = 5;
-  bool tls_reqcert = 6;
 }
 .RE
 .fi
@@ -475,22 +472,6 @@ This can be used to implement log server redundancy and allows the
 client to discover all other log servers simply by connecting to
 one known server.
 This member may be omitted when there is only a single log server.
-.TP 8n
-tls
-If set to true, the connection between the client and the server
-must be secured via Transport Layer Security (TLS) version 1.2 or
-higher.
-.TP 8n
-tls_server_auth
-If set to true, the client should validate the server's certificate
-and only proceed if the certificate can be verified.
-.TP 8n
-tls_reqcert
-If set to true, the client must present its own certificate to the server.
-If the server is unable to verify the client's certificate, the TLS
-handshake will fail.
-This can be used by the server to only allow connections from authorized
-clients.
 .SS "TimeSpec commit_point"
 A periodic time stamp sent by the server to indicate when I/O log
 buffers have been committed to storage.
@@ -529,7 +510,9 @@ message.
 The expected protocol flow is as follows:
 .TP 5n
 1.\&
-Client connect to server.
+Client connects to the first available server.
+If the client is configured to use TLS, a TLS handshake will be
+attempted.
 .TP 5n
 2.\&
 Server sends
@@ -573,6 +556,14 @@ if one is pending.
 .TP 5n
 9.\&
 Server closes the connection.
+After receiving the final
+\fIcommit_point\fR,
+the client client shuts down its side of the TLS connection if TLS
+is in use, and closes the connection.
+.TP 5n
+10.\&
+Server shuts down its side of the TLS connection if TLS is in use,
+and closes the connection.
 .PP
 At any point, the server may send an
 \fIerror\fR

--- a/doc/sudo_logsrv.proto.man.in
+++ b/doc/sudo_logsrv.proto.man.in
@@ -16,7 +16,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.TH "SUDO_LOGSRV.PROTO" "@mansectform@" "April 30, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
+.TH "SUDO_LOGSRV.PROTO" "@mansectform@" "May 4, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
 .nh
 .if n .ad l
 .SH "NAME"
@@ -71,6 +71,7 @@ message ClientMessage {
     IoBuffer stderr_buf = 10;
     ChangeWindowSize winsize_event = 11;
     CommandSuspend suspend_event = 12;
+    ClientHello hello_msg = 13;
   }
 }
 .RE
@@ -130,6 +131,23 @@ entries.
 See the
 \fIEVENT LOG VARIABLES\fR
 section for more information.
+.SS "ClientHello hello_msg"
+.nf
+.RS 0n
+message ClientHello {
+  string client_id = 1;
+}
+.RE
+.fi
+.PP
+A
+\fIClientHello\fR
+message consists of client information that may be sent to the
+server when the client first connects.
+.TP 8n
+client_id
+A free-form client description.
+This usually includes the name and version of the client implementation.
 .SS "AcceptMessage accept_msg"
 .nf
 .RS 0n
@@ -515,17 +533,23 @@ If the client is configured to use TLS, a TLS handshake will be
 attempted.
 .TP 5n
 2.\&
+Client sends
+\fIClientHello\fR.
+This is currently optional but allows the server to detect a
+non-TLS connection on the TLS port.
+.TP 5n
+3.\&
 Server sends
 \fIServerHello\fR.
 .TP 5n
-3.\&
+4.\&
 Client responds with either
 \fIAcceptMessage\fR,
 \fIRejectMessage\fR,
 or
 \fIRestartMessage\fR.
 .TP 5n
-4.\&
+5.\&
 If client sent a
 \fIAcceptMessage\fR
 with
@@ -533,35 +557,35 @@ with
 set, server creates a new I/O log and responds with a
 \fIlog_id\fR.
 .TP 5n
-5.\&
+6.\&
 Client sends zero or more
 \fIIoBuffer\fR
 messages.
 .TP 5n
-6.\&
+7.\&
 Server periodically responds to
 \fIIoBuffer\fR
 messages with a
 \fIcommit_point\fR.
 .TP 5n
-7.\&
+8.\&
 Client sends an
 \fIExitMessage\fR
 when the command exits or is killed.
 .TP 5n
-8.\&
+9.\&
 Server sends the final
 \fIcommit_point\fR
 if one is pending.
 .TP 5n
-9.\&
+10.\&
 Server closes the connection.
 After receiving the final
 \fIcommit_point\fR,
 the client client shuts down its side of the TLS connection if TLS
 is in use, and closes the connection.
 .TP 5n
-10.\&
+11.\&
 Server shuts down its side of the TLS connection if TLS is in use,
 and closes the connection.
 .PP

--- a/doc/sudo_logsrv.proto.mdoc.in
+++ b/doc/sudo_logsrv.proto.mdoc.in
@@ -15,7 +15,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd April 20, 2020
+.Dd April 30, 2020
 .Dt SUDO_LOGSRV.PROTO @mansectform@
 .Os Sudo @PACKAGE_VERSION@
 .Sh NAME
@@ -404,9 +404,6 @@ message ServerHello {
   string server_id = 1;
   string redirect = 2;
   repeated string servers = 3;
-  bool tls = 4;
-  bool tls_server_auth = 5;
-  bool tls_reqcert = 6;
 }
 .Ed
 .Pp
@@ -437,19 +434,6 @@ This can be used to implement log server redundancy and allows the
 client to discover all other log servers simply by connecting to
 one known server.
 This member may be omitted when there is only a single log server.
-.It tls
-If set to true, the connection between the client and the server
-must be secured via Transport Layer Security (TLS) version 1.2 or
-higher.
-.It tls_server_auth
-If set to true, the client should validate the server's certificate
-and only proceed if the certificate can be verified.
-.It tls_reqcert
-If set to true, the client must present its own certificate to the server.
-If the server is unable to verify the client's certificate, the TLS
-handshake will fail.
-This can be used by the server to only allow connections from authorized
-clients.
 .El
 .Ss TimeSpec commit_point
 A periodic time stamp sent by the server to indicate when I/O log
@@ -489,7 +473,9 @@ message.
 The expected protocol flow is as follows:
 .Bl -enum
 .It
-Client connect to server.
+Client connects to the first available server.
+If the client is configured to use TLS, a TLS handshake will be
+attempted.
 .It
 Server sends
 .Em ServerHello .
@@ -525,6 +511,13 @@ Server sends the final
 if one is pending.
 .It
 Server closes the connection.
+After receiving the final
+.Em commit_point ,
+the client client shuts down its side of the TLS connection if TLS
+is in use, and closes the connection.
+.It
+Server shuts down its side of the TLS connection if TLS is in use,
+and closes the connection.
 .El
 .Pp
 At any point, the server may send an

--- a/doc/sudo_logsrv.proto.mdoc.in
+++ b/doc/sudo_logsrv.proto.mdoc.in
@@ -15,7 +15,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd April 30, 2020
+.Dd May 4, 2020
 .Dt SUDO_LOGSRV.PROTO @mansectform@
 .Os Sudo @PACKAGE_VERSION@
 .Sh NAME
@@ -68,6 +68,7 @@ message ClientMessage {
     IoBuffer stderr_buf = 10;
     ChangeWindowSize winsize_event = 11;
     CommandSuspend suspend_event = 12;
+    ClientHello hello_msg = 13;
   }
 }
 .Ed
@@ -122,6 +123,22 @@ entries.
 See the
 .Sx EVENT LOG VARIABLES
 section for more information.
+.Ss ClientHello hello_msg
+.Bd -literal
+message ClientHello {
+  string client_id = 1;
+}
+.Ed
+.Pp
+A
+.Em ClientHello
+message consists of client information that may be sent to the
+server when the client first connects.
+.Bl -tag -width Ds
+.It client_id
+A free-form client description.
+This usually includes the name and version of the client implementation.
+.El
 .Ss AcceptMessage accept_msg
 .Bd -literal
 message AcceptMessage {
@@ -476,6 +493,11 @@ The expected protocol flow is as follows:
 Client connects to the first available server.
 If the client is configured to use TLS, a TLS handshake will be
 attempted.
+.It
+Client sends
+.Em ClientHello .
+This is currently optional but allows the server to detect a
+non-TLS connection on the TLS port.
 .It
 Server sends
 .Em ServerHello .

--- a/doc/sudo_logsrvd.conf.man.in
+++ b/doc/sudo_logsrvd.conf.man.in
@@ -97,7 +97,7 @@ will cause
 \fBsudo_logsrvd\fR
 to listen on all configured network interfaces.
 .sp
-If the tls flag is present,
+If the optional tls flag is present,
 \fBsudo_logsrvd\fR
 will secure the connection with TLS version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.

--- a/doc/sudo_logsrvd.conf.man.in
+++ b/doc/sudo_logsrvd.conf.man.in
@@ -16,7 +16,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.TH "SUDO_LOGSRVD.CONF" "@mansectform@" "March 28, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
+.TH "SUDO_LOGSRVD.CONF" "@mansectform@" "April 30, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
 .nh
 .if n .ad l
 .SH "NAME"
@@ -84,9 +84,10 @@ The
 section configures the address and port the server will listen on.
 The following keys are recognized:
 .TP 10n
-listen_address = host[:port]
-The host name or IP address and optional port to listen on.
-If no port is specified, port 30344 will be used.
+listen_address = host[:port][(tls)]
+The host name or IP address, optional port to listen on and
+an optional Transport Layer Security (TLS) flag in parentheses.
+.sp
 The host may be a host name, an IPv4 address, an IPv6 address
 in square brackets or the wild card entry
 \(oq*\(cq.
@@ -96,14 +97,33 @@ will cause
 \fBsudo_logsrvd\fR
 to listen on all configured network interfaces.
 .sp
+If the tls flag is set,
+\fBsudo_logsrvd\fR
+will secure the connection with TLS version 1.2 or 1.3.
+Versions of TLS prior to 1.2 are not supported.
+See
+sudo_logsrvd(8)
+for details on generating TLS keys and certificates.
+.sp
 If a port is specified, it may either be a port number or a known
 service name as defined by the system service name database.
-The default value is
-\fRlisten_address = *:30344\fR
-which will listen on all configured network interfaces.
+If no port is specified, port 30343 will be used for plaintext
+connections and port 30344 will be used for TLS connections.
+.sp
+The default value is:
+.nf
+.RS 16n
+listen_address = *:30343
+listen_address = *:30344(tls)
+.RE
+.fi
+.RS 10n
+which will listen on all configured network interfaces for both
+plaintext and TLS connections.
 Multiple
 \fIlisten_address\fR
-lines may be specified to listen on more than one interface.
+lines may be specified to listen on more than one port or interface.
+.RE
 .TP 10n
 pid_file = path
 The path to the file containing the process ID of the running
@@ -129,17 +149,6 @@ The amount of time, in seconds,
 will wait for the client to respond.
 A value of 0 will disable the timeout.
 The default value is 30.
-.TP 10n
-tls = boolean
-If true,
-\fBsudo_logsrvd\fR
-will secure network connections with Transport Layer Security (TLS)
-version 1.2 or 1.3.
-Versions of TLS prior to 1.2 are not supported.
-See
-sudo_logsrvd(8)
-for details on generating TLS keys and certificates.
-The default value is false.
 .TP 10n
 tls_cacert = path
 The path to a certificate authority bundle file, in PEM format,
@@ -552,19 +561,23 @@ Sudo log server configuration file
 #
 
 [server]
-# The host name or IP address and port to listen on.  If no port is
-# specified, port 30344 will be used.
+# The host name or IP address and port to listen on with an optional TLS
+# flag.  If no port is specified, port 30343 will be used for plaintext
+# connections and port 30344 will be used to TLS connections.
 # The following forms are accepted:
-#   listen_address = hostname
-#   listen_address = hostname:port
-#   listen_address = IPv4_address
-#   listen_address = IPv4_address:port
-#   listen_address = [IPv6_address]
-#   listen_address = [IPv6_address]:port
+#   listen_address = hostname(tls)
+#   listen_address = hostname:port(tls)
+#   listen_address = IPv4_address(tls)
+#   listen_address = IPv4_address:port(tls)
+#   listen_address = [IPv6_address](tls)
+#   listen_address = [IPv6_address]:port(tls)
+#
+# The (tls) suffix should be omitted for plaintext connections.
 #
 # Multiple listen_address settings may be specified.
 # The default is to listen on all addresses.
-#listen_address = *:30344
+#listen_address = *:30343
+#listen_address = *:30344(tls)
 
 # The file containing the ID of the running sudo_logsrvd process.
 #pid_file = @rundir@/sudo_logsrvd.pid
@@ -575,10 +588,6 @@ Sudo log server configuration file
 # The amount of time, in seconds, the server will wait for the client to
 # respond.  A value of 0 will disable the timeout.  The default value is 30.
 #timeout = 30
-
-# If set, secure connections with TLS 1.2 or 1.3.
-# By default, server connections are not encrypted.
-#tls = true
 
 # If set, server certificate will be verified at server startup and
 # also connecting clients will perform server authentication by

--- a/doc/sudo_logsrvd.conf.man.in
+++ b/doc/sudo_logsrvd.conf.man.in
@@ -97,7 +97,7 @@ will cause
 \fBsudo_logsrvd\fR
 to listen on all configured network interfaces.
 .sp
-If the tls flag is set,
+If the tls flag is present,
 \fBsudo_logsrvd\fR
 will secure the connection with TLS version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.

--- a/doc/sudo_logsrvd.conf.mdoc.in
+++ b/doc/sudo_logsrvd.conf.mdoc.in
@@ -89,7 +89,7 @@ will cause
 .Nm sudo_logsrvd
 to listen on all configured network interfaces.
 .Pp
-If the tls flag is set,
+If the tls flag is present,
 .Nm sudo_logsrvd
 will secure the connection with TLS version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.

--- a/doc/sudo_logsrvd.conf.mdoc.in
+++ b/doc/sudo_logsrvd.conf.mdoc.in
@@ -89,7 +89,7 @@ will cause
 .Nm sudo_logsrvd
 to listen on all configured network interfaces.
 .Pp
-If the tls flag is present,
+If the optional tls flag is present,
 .Nm sudo_logsrvd
 will secure the connection with TLS version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.

--- a/doc/sudo_logsrvd.conf.mdoc.in
+++ b/doc/sudo_logsrvd.conf.mdoc.in
@@ -15,7 +15,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd March 28, 2020
+.Dd April 30, 2020
 .Dt SUDO_LOGSRVD.CONF @mansectform@
 .Os Sudo @PACKAGE_VERSION@
 .Sh NAME
@@ -76,9 +76,10 @@ The
 section configures the address and port the server will listen on.
 The following keys are recognized:
 .Bl -tag -width 8n
-.It listen_address = host Ns Op : Ns port
-The host name or IP address and optional port to listen on.
-If no port is specified, port 30344 will be used.
+.It listen_address = host Ns Oo : Ns port Oc Ns Op (tls)
+The host name or IP address, optional port to listen on and
+an optional Transport Layer Security (TLS) flag in parentheses.
+.Pp
 The host may be a host name, an IPv4 address, an IPv6 address
 in square brackets or the wild card entry
 .Ql * .
@@ -88,14 +89,29 @@ will cause
 .Nm sudo_logsrvd
 to listen on all configured network interfaces.
 .Pp
+If the tls flag is set,
+.Nm sudo_logsrvd
+will secure the connection with TLS version 1.2 or 1.3.
+Versions of TLS prior to 1.2 are not supported.
+See
+.Xr sudo_logsrvd @mansectsu@
+for details on generating TLS keys and certificates.
+.Pp
 If a port is specified, it may either be a port number or a known
 service name as defined by the system service name database.
-The default value is
-.Li listen_address = *:30344
-which will listen on all configured network interfaces.
+If no port is specified, port 30343 will be used for plaintext
+connections and port 30344 will be used for TLS connections.
+.Pp
+The default value is:
+.Bd -literal -compact -offset indent
+listen_address = *:30343
+listen_address = *:30344(tls)
+.Ed
+which will listen on all configured network interfaces for both
+plaintext and TLS connections.
 Multiple
 .Em listen_address
-lines may be specified to listen on more than one interface.
+lines may be specified to listen on more than one port or interface.
 .It pid_file = path
 The path to the file containing the process ID of the running
 .Nm sudo_logsrvd .
@@ -118,16 +134,6 @@ The amount of time, in seconds,
 will wait for the client to respond.
 A value of 0 will disable the timeout.
 The default value is 30.
-.It tls = boolean
-If true,
-.Nm sudo_logsrvd
-will secure network connections with Transport Layer Security (TLS)
-version 1.2 or 1.3.
-Versions of TLS prior to 1.2 are not supported.
-See
-.Xr sudo_logsrvd @mansectsu@
-for details on generating TLS keys and certificates.
-The default value is false.
 .It tls_cacert = path
 The path to a certificate authority bundle file, in PEM format,
 to use instead of the system's default certificate authority database
@@ -500,19 +506,23 @@ Sudo log server configuration file
 #
 
 [server]
-# The host name or IP address and port to listen on.  If no port is
-# specified, port 30344 will be used.
+# The host name or IP address and port to listen on with an optional TLS
+# flag.  If no port is specified, port 30343 will be used for plaintext
+# connections and port 30344 will be used to TLS connections.
 # The following forms are accepted:
-#   listen_address = hostname
-#   listen_address = hostname:port
-#   listen_address = IPv4_address
-#   listen_address = IPv4_address:port
-#   listen_address = [IPv6_address]
-#   listen_address = [IPv6_address]:port
+#   listen_address = hostname(tls)
+#   listen_address = hostname:port(tls)
+#   listen_address = IPv4_address(tls)
+#   listen_address = IPv4_address:port(tls)
+#   listen_address = [IPv6_address](tls)
+#   listen_address = [IPv6_address]:port(tls)
+#
+# The (tls) suffix should be omitted for plaintext connections.
 #
 # Multiple listen_address settings may be specified.
 # The default is to listen on all addresses.
-#listen_address = *:30344
+#listen_address = *:30343
+#listen_address = *:30344(tls)
 
 # The file containing the ID of the running sudo_logsrvd process.
 #pid_file = @rundir@/sudo_logsrvd.pid
@@ -523,10 +533,6 @@ Sudo log server configuration file
 # The amount of time, in seconds, the server will wait for the client to
 # respond.  A value of 0 will disable the timeout.  The default value is 30.
 #timeout = 30
-
-# If set, secure connections with TLS 1.2 or 1.3.
-# By default, server connections are not encrypted.
-#tls = true
 
 # If set, server certificate will be verified at server startup and
 # also connecting clients will perform server authentication by

--- a/doc/sudo_sendlog.man.in
+++ b/doc/sudo_sendlog.man.in
@@ -16,7 +16,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.TH "SUDO_SENDLOG" "@mansectsu@" "April 23, 2020" "Sudo @PACKAGE_VERSION@" "System Manager's Manual"
+.TH "SUDO_SENDLOG" "@mansectsu@" "April 30, 2020" "Sudo @PACKAGE_VERSION@" "System Manager's Manual"
 .nh
 .if n .ad l
 .SH "NAME"
@@ -25,7 +25,7 @@
 .SH "SYNOPSIS"
 .HP 13n
 \fBsudo_sendlog\fR
-[\fB\-V\fR]
+[\fB\-nV\fR]
 [\fB\-b\fR\ \fIca_bundle\fR]
 [\fB\-c\fR\ \fIcert_file\fR]
 [\fB\-h\fR\ \fIhost\fR]
@@ -54,13 +54,7 @@ when authenticating the log server.
 The default is to use the system's default certificate authority database.
 .TP 12n
 \fB\-c\fR, \fB\--cert\fR
-The path to the client's certificate file, in PEM format.
-This setting is required when the connection to the remote log server
-is secured with TLS.
-.TP 12n
-\fB\-k\fR, \fB\--key\fR
-.br
-The path to the client's private key file, in PEM format.
+The path to the client's certificate file in PEM format.
 This setting is required when the connection to the remote log server
 is secured with TLS.
 .TP 12n
@@ -82,6 +76,22 @@ is reported by the server when it creates the remote I/O log.
 This option may only be used in conjunction with the
 \fB\-r\fR
 option.
+.TP 12n
+\fB\-k\fR, \fB\--key\fR
+.br
+The path to the client's private key file in PEM format.
+This setting is required when the connection to the remote log server
+is secured with TLS.
+.TP 12n
+\fB\-n\fR, \fB\--no-verify\fR
+If specified, the server's certificate will not be verified during
+the TLS handshake.
+By default,
+\fBsudo_sendlog\fR
+verifies that the server's certificate is valid and that it contains either
+the server's host name or its IP address.
+This setting is only supported when the connection to the remote log server
+is secured with TLS.
 .TP 12n
 \fB\-p\fR, \fB\--port\fR
 Use the specified network

--- a/doc/sudo_sendlog.mdoc.in
+++ b/doc/sudo_sendlog.mdoc.in
@@ -15,7 +15,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd April 23, 2020
+.Dd April 30, 2020
 .Dt SUDO_SENDLOG @mansectsu@
 .Os Sudo @PACKAGE_VERSION@
 .Sh NAME
@@ -23,7 +23,7 @@
 .Nd send sudo I/O log to log server
 .Sh SYNOPSIS
 .Nm sudo_sendlog
-.Op Fl V
+.Op Fl nV
 .Op Fl b Ar ca_bundle
 .Op Fl c Ar cert_file
 .Op Fl h Ar host
@@ -51,11 +51,7 @@ to use instead of the system's default certificate authority database
 when authenticating the log server.
 The default is to use the system's default certificate authority database.
 .It Fl c , -cert
-The path to the client's certificate file, in PEM format.
-This setting is required when the connection to the remote log server
-is secured with TLS.
-.It Fl k , -key
-The path to the client's private key file, in PEM format.
+The path to the client's certificate file in PEM format.
 This setting is required when the connection to the remote log server
 is secured with TLS.
 .It Fl -help
@@ -74,6 +70,19 @@ is reported by the server when it creates the remote I/O log.
 This option may only be used in conjunction with the
 .Fl r
 option.
+.It Fl k , -key
+The path to the client's private key file in PEM format.
+This setting is required when the connection to the remote log server
+is secured with TLS.
+.It Fl n , -no-verify
+If specified, the server's certificate will not be verified during
+the TLS handshake.
+By default,
+.Nm
+verifies that the server's certificate is valid and that it contains either
+the server's host name or its IP address.
+This setting is only supported when the connection to the remote log server
+is secured with TLS.
 .It Fl p , -port
 Use the specified network
 .Ar port

--- a/doc/sudoers.man.in
+++ b/doc/sudoers.man.in
@@ -25,7 +25,7 @@
 .nr BA @BAMAN@
 .nr LC @LCMAN@
 .nr PS @PSMAN@
-.TH "SUDOERS" "@mansectform@" "April 3, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
+.TH "SUDOERS" "@mansectform@" "April 30, 2020" "Sudo @PACKAGE_VERSION@" "File Formats Manual"
 .nh
 .if n .ad l
 .SH "NAME"
@@ -2627,6 +2627,18 @@ This flag is
 \fIon\fR
 by default.
 .TP 18n
+log_server_verify
+.br
+If set, the server certificate received during the TLS handshake
+must be valid and it must contain either the server name (from
+\fIlog_servers\fR)
+or its IP address.
+If either of these conditions is not met, the TLS handshake will fail.
+This flag is
+\fIon\fR
+by default.
+\fBsudo\fR
+.TP 18n
 log_year
 If set, the four-digit year will be logged in the (non-syslog)
 \fBsudo\fR
@@ -4608,21 +4620,32 @@ Starting with
 logging them locally.
 The
 \fIlog_servers\fR
-setting specifies one or more server addresses to use when storing
-I/O logs remotely.
+setting specifies one or more hosts to connect to for
+remote I/O log storage.
 Log servers must be running
 \fBsudo_logsrvd\fR
 or another service that implements the protocol described by
 sudo_logsrv.proto(@mansectform@).
+.sp
 Server addresses should be of the form
-\(lqhost[:port]\(rq.
-If no port is specified, port 30344 will be used.
+\(lqhost[:port][(tls)]\(rq.
 The host portion may be a host name, an IPv4 address, or an IPv6 address
 in square brackets.
+If the tls flag is present, the connection will be secured
+with Transport Layer Security (TLS) version 1.2 or 1.3.
+Versions of TLS prior to 1.2 are not supported.
+.sp
+If a port is specified, it may either be a port number or a known
+service name as defined by the system service name database.
+If no port is specified, port 30343 will be used for plaintext
+connections and port 30344 will be used for TLS connections.
 .sp
 When
 \fIlog_servers\fR
 is enabled, I/O logs will not be logged locally.
+If multiple hosts are specified,
+\fBsudoers\fR
+will try them in reverse order until it connects successfully.
 If no log servers are reachable, the user will not be able
 to run a command unless the
 \fIignore_iolog_errors\fR

--- a/doc/sudoers.man.in
+++ b/doc/sudoers.man.in
@@ -4631,7 +4631,8 @@ Server addresses should be of the form
 \(lqhost[:port][(tls)]\(rq.
 The host portion may be a host name, an IPv4 address, or an IPv6 address
 in square brackets.
-If the tls flag is present, the connection will be secured
+.sp
+If the optional tls flag is present, the connection will be secured
 with Transport Layer Security (TLS) version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.
 .sp

--- a/doc/sudoers.mdoc.in
+++ b/doc/sudoers.mdoc.in
@@ -24,7 +24,7 @@
 .nr BA @BAMAN@
 .nr LC @LCMAN@
 .nr PS @PSMAN@
-.Dd April 3, 2020
+.Dd April 30, 2020
 .Dt SUDOERS @mansectform@
 .Os Sudo @PACKAGE_VERSION@
 .Sh NAME
@@ -2473,6 +2473,16 @@ flag is set.
 This flag is
 .Em on
 by default.
+.It log_server_verify
+If set, the server certificate received during the TLS handshake
+must be valid and it must contain either the server name (from
+.Em log_servers )
+or its IP address.
+If either of these conditions is not met, the TLS handshake will fail.
+This flag is
+.Em on
+by default.
+.Nm sudo
 .It log_year
 If set, the four-digit year will be logged in the (non-syslog)
 .Nm sudo
@@ -4300,21 +4310,32 @@ Starting with
 logging them locally.
 The
 .Em log_servers
-setting specifies one or more server addresses to use when storing
-I/O logs remotely.
+setting specifies one or more hosts to connect to for
+remote I/O log storage.
 Log servers must be running
 .Nm sudo_logsrvd
 or another service that implements the protocol described by
 .Xr sudo_logsrv.proto @mansectform@ .
+.Pp
 Server addresses should be of the form
-.Dq host Ns Op : Ns port .
-If no port is specified, port 30344 will be used.
+.Dq host Ns Oo : Ns port Oc Ns Op (tls) .
 The host portion may be a host name, an IPv4 address, or an IPv6 address
 in square brackets.
+If the tls flag is present, the connection will be secured
+with Transport Layer Security (TLS) version 1.2 or 1.3.
+Versions of TLS prior to 1.2 are not supported.
+.Pp
+If a port is specified, it may either be a port number or a known
+service name as defined by the system service name database.
+If no port is specified, port 30343 will be used for plaintext
+connections and port 30344 will be used for TLS connections.
 .Pp
 When
 .Em log_servers
 is enabled, I/O logs will not be logged locally.
+If multiple hosts are specified,
+.Nm
+will try them in reverse order until it connects successfully.
 If no log servers are reachable, the user will not be able
 to run a command unless the
 .Em ignore_iolog_errors

--- a/doc/sudoers.mdoc.in
+++ b/doc/sudoers.mdoc.in
@@ -4321,7 +4321,8 @@ Server addresses should be of the form
 .Dq host Ns Oo : Ns port Oc Ns Op (tls) .
 The host portion may be a host name, an IPv4 address, or an IPv6 address
 in square brackets.
-If the tls flag is present, the connection will be secured
+.Pp
+If the optional tls flag is present, the connection will be secured
 with Transport Layer Security (TLS) version 1.2 or 1.3.
 Versions of TLS prior to 1.2 are not supported.
 .Pp

--- a/examples/sudo_logsrvd.conf
+++ b/examples/sudo_logsrvd.conf
@@ -3,19 +3,23 @@
 #
 
 [server]
-# The host name or IP address and port to listen on.  If no port is
-# specified, port 30344 will be used.
+# The host name or IP address and port to listen on with an optional TLS
+# flag.  If no port is specified, port 30343 will be used for plaintext
+# connections and port 30344 will be used to TLS connections.
 # The following forms are accepted:
-#   listen_address = hostname
-#   listen_address = hostname:port
-#   listen_address = IPv4_address
-#   listen_address = IPv4_address:port
-#   listen_address = [IPv6_address]
-#   listen_address = [IPv6_address]:port
+#   listen_address = hostname(tls)
+#   listen_address = hostname:port(tls)
+#   listen_address = IPv4_address(tls)
+#   listen_address = IPv4_address:port(tls)
+#   listen_address = [IPv6_address](tls)
+#   listen_address = [IPv6_address]:port(tls)
+#
+# The (tls) suffix should be omitted for plaintext connections.
 #
 # Multiple listen_address settings may be specified.
 # The default is to listen on all addresses.
-#listen_address = *:30344
+#listen_address = *:30343
+#listen_address = *:30344(tls)
 
 # The file containing the ID of the running sudo_logsrvd process.
 #pid_file = /var/run/sudo/sudo_logsrvd.pid
@@ -26,10 +30,6 @@
 # The amount of time, in seconds, the server will wait for the client to
 # respond.  A value of 0 will disable the timeout.  The default value is 30.
 #timeout = 30
-
-# If set, secure connections with TLS 1.2 or 1.3.
-# By default, server connections are not encrypted.
-#tls = true
 
 # If set, server certificate will be verified at server startup and
 # also connecting clients will perform server authentication by

--- a/include/log_server.pb-c.h
+++ b/include/log_server.pb-c.h
@@ -405,22 +405,10 @@ struct  _ServerHello
    */
   size_t n_servers;
   char **servers;
-  /*
-   * true if server uses tls protocol 
-   */
-  protobuf_c_boolean tls;
-  /*
-   * true if server auth has to be performed 
-   */
-  protobuf_c_boolean tls_server_auth;
-  /*
-   * true if client auth is required with signed cert 
-   */
-  protobuf_c_boolean tls_reqcert;
 };
 #define SERVER_HELLO__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&server_hello__descriptor) \
-    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL, 0, 0, 0 }
+    , (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL }
 
 
 /* ClientMessage methods */

--- a/include/log_server.pb-c.h
+++ b/include/log_server.pb-c.h
@@ -28,6 +28,7 @@ typedef struct _AlertMessage AlertMessage;
 typedef struct _RestartMessage RestartMessage;
 typedef struct _ChangeWindowSize ChangeWindowSize;
 typedef struct _CommandSuspend CommandSuspend;
+typedef struct _ClientHello ClientHello;
 typedef struct _ServerMessage ServerMessage;
 typedef struct _ServerHello ServerHello;
 
@@ -50,7 +51,8 @@ typedef enum {
   CLIENT_MESSAGE__TYPE_STDOUT_BUF = 9,
   CLIENT_MESSAGE__TYPE_STDERR_BUF = 10,
   CLIENT_MESSAGE__TYPE_WINSIZE_EVENT = 11,
-  CLIENT_MESSAGE__TYPE_SUSPEND_EVENT = 12
+  CLIENT_MESSAGE__TYPE_SUSPEND_EVENT = 12,
+  CLIENT_MESSAGE__TYPE_HELLO_MSG = 13
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CLIENT_MESSAGE__TYPE)
 } ClientMessage__TypeCase;
 
@@ -75,6 +77,7 @@ struct  _ClientMessage
     IoBuffer *stderr_buf;
     ChangeWindowSize *winsize_event;
     CommandSuspend *suspend_event;
+    ClientHello *hello_msg;
   };
 };
 #define CLIENT_MESSAGE__INIT \
@@ -338,6 +341,22 @@ struct  _CommandSuspend
 #define COMMAND_SUSPEND__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&command_suspend__descriptor) \
     , NULL, (char *)protobuf_c_empty_string }
+
+
+/*
+ * Hello message from client when connecting to server. 
+ */
+struct  _ClientHello
+{
+  ProtobufCMessage base;
+  /*
+   * free-form client description 
+   */
+  char *client_id;
+};
+#define CLIENT_HELLO__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&client_hello__descriptor) \
+    , (char *)protobuf_c_empty_string }
 
 
 typedef enum {
@@ -626,6 +645,25 @@ CommandSuspend *
 void   command_suspend__free_unpacked
                      (CommandSuspend *message,
                       ProtobufCAllocator *allocator);
+/* ClientHello methods */
+void   client_hello__init
+                     (ClientHello         *message);
+size_t client_hello__get_packed_size
+                     (const ClientHello   *message);
+size_t client_hello__pack
+                     (const ClientHello   *message,
+                      uint8_t             *out);
+size_t client_hello__pack_to_buffer
+                     (const ClientHello   *message,
+                      ProtobufCBuffer     *buffer);
+ClientHello *
+       client_hello__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   client_hello__free_unpacked
+                     (ClientHello *message,
+                      ProtobufCAllocator *allocator);
 /* ServerMessage methods */
 void   server_message__init
                      (ServerMessage         *message);
@@ -705,6 +743,9 @@ typedef void (*ChangeWindowSize_Closure)
 typedef void (*CommandSuspend_Closure)
                  (const CommandSuspend *message,
                   void *closure_data);
+typedef void (*ClientHello_Closure)
+                 (const ClientHello *message,
+                  void *closure_data);
 typedef void (*ServerMessage_Closure)
                  (const ServerMessage *message,
                   void *closure_data);
@@ -730,6 +771,7 @@ extern const ProtobufCMessageDescriptor alert_message__descriptor;
 extern const ProtobufCMessageDescriptor restart_message__descriptor;
 extern const ProtobufCMessageDescriptor change_window_size__descriptor;
 extern const ProtobufCMessageDescriptor command_suspend__descriptor;
+extern const ProtobufCMessageDescriptor client_hello__descriptor;
 extern const ProtobufCMessageDescriptor server_message__descriptor;
 extern const ProtobufCMessageDescriptor server_hello__descriptor;
 

--- a/include/sudo_util.h
+++ b/include/sudo_util.h
@@ -208,8 +208,8 @@ __dso_public int sudo_getgrouplist2_v1(const char *name, gid_t basegid, GETGROUP
 #define sudo_getgrouplist2(_a, _b, _c, _d) sudo_getgrouplist2_v1((_a), (_b), (_c), (_d))
 
 /* host_port.c */
-__dso_public bool sudo_parse_host_port_v1(char *str, char **hostp, char **portp, char *defport);
-#define sudo_parse_host_port(_a, _b, _c, _d) sudo_parse_host_port_v1((_a), (_b), (_c), (_d))
+__dso_public bool sudo_parse_host_port_v1(char *str, char **hostp, char **portp, bool *tlsp, char *defport, char *defport_tls);
+#define sudo_parse_host_port(_a, _b, _c, _d, _e, _f) sudo_parse_host_port_v1((_a), (_b), (_c), (_d), (_e), (_f))
 
 /* key_val.c */
 __dso_public char *sudo_new_key_val_v1(const char *key, const char *value);

--- a/lib/logsrv/log_server.pb-c.c
+++ b/lib/logsrv/log_server.pb-c.c
@@ -1578,7 +1578,7 @@ const ProtobufCMessageDescriptor server_message__descriptor =
   (ProtobufCMessageInit) server_message__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor server_hello__field_descriptors[6] =
+static const ProtobufCFieldDescriptor server_hello__field_descriptors[3] =
 {
   {
     "server_id",
@@ -1616,55 +1616,16 @@ static const ProtobufCFieldDescriptor server_hello__field_descriptors[6] =
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
-  {
-    "tls",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(ServerHello, tls),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "tls_server_auth",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(ServerHello, tls_server_auth),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "tls_reqcert",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(ServerHello, tls_reqcert),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
 };
 static const unsigned server_hello__field_indices_by_name[] = {
   1,   /* field[1] = redirect */
   0,   /* field[0] = server_id */
   2,   /* field[2] = servers */
-  3,   /* field[3] = tls */
-  5,   /* field[5] = tls_reqcert */
-  4,   /* field[4] = tls_server_auth */
 };
 static const ProtobufCIntRange server_hello__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 6 }
+  { 0, 3 }
 };
 const ProtobufCMessageDescriptor server_hello__descriptor =
 {
@@ -1674,7 +1635,7 @@ const ProtobufCMessageDescriptor server_hello__descriptor =
   "ServerHello",
   "",
   sizeof(ServerHello),
-  6,
+  3,
   server_hello__field_descriptors,
   server_hello__field_indices_by_name,
   1,  server_hello__number_ranges,

--- a/lib/logsrv/log_server.pb-c.c
+++ b/lib/logsrv/log_server.pb-c.c
@@ -514,6 +514,51 @@ void   command_suspend__free_unpacked
   assert(message->base.descriptor == &command_suspend__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
+void   client_hello__init
+                     (ClientHello         *message)
+{
+  static const ClientHello init_value = CLIENT_HELLO__INIT;
+  *message = init_value;
+}
+size_t client_hello__get_packed_size
+                     (const ClientHello *message)
+{
+  assert(message->base.descriptor == &client_hello__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t client_hello__pack
+                     (const ClientHello *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &client_hello__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t client_hello__pack_to_buffer
+                     (const ClientHello *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &client_hello__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+ClientHello *
+       client_hello__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (ClientHello *)
+     protobuf_c_message_unpack (&client_hello__descriptor,
+                                allocator, len, data);
+}
+void   client_hello__free_unpacked
+                     (ClientHello *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &client_hello__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
 void   server_message__init
                      (ServerMessage         *message)
 {
@@ -604,7 +649,7 @@ void   server_hello__free_unpacked
   assert(message->base.descriptor == &server_hello__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor client_message__field_descriptors[12] =
+static const ProtobufCFieldDescriptor client_message__field_descriptors[13] =
 {
   {
     "accept_msg",
@@ -750,11 +795,24 @@ static const ProtobufCFieldDescriptor client_message__field_descriptors[12] =
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "hello_msg",
+    13,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(ClientMessage, type_case),
+    offsetof(ClientMessage, hello_msg),
+    &client_hello__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned client_message__field_indices_by_name[] = {
   0,   /* field[0] = accept_msg */
   4,   /* field[4] = alert_msg */
   2,   /* field[2] = exit_msg */
+  12,   /* field[12] = hello_msg */
   1,   /* field[1] = reject_msg */
   3,   /* field[3] = restart_msg */
   9,   /* field[9] = stderr_buf */
@@ -768,7 +826,7 @@ static const unsigned client_message__field_indices_by_name[] = {
 static const ProtobufCIntRange client_message__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 12 }
+  { 0, 13 }
 };
 const ProtobufCMessageDescriptor client_message__descriptor =
 {
@@ -778,7 +836,7 @@ const ProtobufCMessageDescriptor client_message__descriptor =
   "ClientMessage",
   "",
   sizeof(ClientMessage),
-  12,
+  13,
   client_message__field_descriptors,
   client_message__field_indices_by_name,
   1,  client_message__number_ranges,
@@ -1486,6 +1544,44 @@ const ProtobufCMessageDescriptor command_suspend__descriptor =
   command_suspend__field_indices_by_name,
   1,  command_suspend__number_ranges,
   (ProtobufCMessageInit) command_suspend__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor client_hello__field_descriptors[1] =
+{
+  {
+    "client_id",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(ClientHello, client_id),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned client_hello__field_indices_by_name[] = {
+  0,   /* field[0] = client_id */
+};
+static const ProtobufCIntRange client_hello__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor client_hello__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "ClientHello",
+  "ClientHello",
+  "ClientHello",
+  "",
+  sizeof(ClientHello),
+  1,
+  client_hello__field_descriptors,
+  client_hello__field_indices_by_name,
+  1,  client_hello__number_ranges,
+  (ProtobufCMessageInit) client_hello__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor server_message__field_descriptors[5] =

--- a/lib/logsrv/log_server.proto
+++ b/lib/logsrv/log_server.proto
@@ -125,7 +125,4 @@ message ServerHello {
   string server_id = 1;		/* free-form server description */
   string redirect = 2;		/* optional redirect if busy */
   repeated string servers = 3;	/* optional list of known servers */
-  bool tls = 4;             /* true if server uses tls protocol */
-  bool tls_server_auth = 5; /* true if server auth has to be performed */
-  bool tls_reqcert = 6;     /* true if client auth is required with signed cert */
 }

--- a/lib/logsrv/log_server.proto
+++ b/lib/logsrv/log_server.proto
@@ -18,6 +18,7 @@ message ClientMessage {
     IoBuffer stderr_buf = 10;
     ChangeWindowSize winsize_event = 11;
     CommandSuspend suspend_event = 12;
+    ClientHello hello_msg = 13;
   }
 }
 
@@ -104,6 +105,11 @@ message ChangeWindowSize {
 message CommandSuspend {
   TimeSpec delay = 1;		/* elapsed time since last record */
   string signal = 2;		/* signal that caused suspend/resume */
+}
+
+/* Hello message from client when connecting to server. */
+message ClientHello {
+  string client_id = 1;		/* free-form client description */
 }
 
 /*

--- a/lib/util/host_port.c
+++ b/lib/util/host_port.c
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: ISC
  *
- * Copyright (c) 2019 Todd C. Miller <Todd.Miller@sudo.ws>
+ * Copyright (c) 2019-2020 Todd C. Miller <Todd.Miller@sudo.ws>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "sudo_gettext.h"	/* must be included before sudo_compat.h */
 #include "sudo_compat.h"
@@ -40,10 +41,12 @@
  * Fills in hostp and portp which may point within str, which is modified.
  */
 bool
-sudo_parse_host_port_v1(char *str, char **hostp, char **portp, char *defport)
+sudo_parse_host_port_v1(char *str, char **hostp, char **portp, bool *tlsp,
+     char *defport, char *defport_tls)
 {
-    char *port, *host = str;
+    char *flags, *port, *host = str;
     bool ret = false;
+    bool tls = false;
     debug_decl(sudo_parse_host_port, SUDO_DEBUG_UTIL);
 
     /* Check for IPv6 address like [::0] followed by optional port */
@@ -56,11 +59,17 @@ sudo_parse_host_port_v1(char *str, char **hostp, char **portp, char *defport)
 	    goto done;
 	}
 	*port++ = '\0';
-	if (*port == ':') {
-	    port++;
-	} else if (*port == '\0') {
-	    port = NULL;		/* no port specified */
-	} else {
+        switch (*port) {
+        case ':':
+            port++;
+            break;
+        case '\0':
+            port = NULL;		/* no port specified */
+            break;
+        case '(':
+            /* flag, handled below */
+            break;
+        default:
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
 		"invalid IPv6 address %s", str);
 	    goto done;
@@ -71,13 +80,24 @@ sudo_parse_host_port_v1(char *str, char **hostp, char **portp, char *defport)
 	    *port++ = '\0';
     }
 
+    /* Check for optional tls flag at the end. */
+    flags = strchr(port ? port : host, '(');
+    if (flags != NULL) {
+	if (strcasecmp(flags, "(tls)") == 0)
+	    tls = true;
+	*flags = '\0';
+	if (port == flags)
+	    port = NULL;
+    }
+
     if (port == NULL)
-	port = defport;
+	port = tls ? defport_tls : defport;
     else if (*port == '\0')
 	goto done;
 
     *hostp = host;
     *portp = port;
+    *tlsp = tls;
 
     ret = true;
 

--- a/logsrvd/logsrv_util.h
+++ b/logsrvd/logsrv_util.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: ISC
  *
- * Copyright (c) 2019 Todd C. Miller <Todd.Miller@sudo.ws>
+ * Copyright (c) 2019-2020 Todd C. Miller <Todd.Miller@sudo.ws>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -19,8 +19,9 @@
 #ifndef SUDO_LOGSRV_UTIL_H
 #define SUDO_LOGSRV_UTIL_H
 
-/* Default port to listen on */
-#define DEFAULT_PORT_STR	"30344"
+/* Default ports to listen on */
+#define DEFAULT_PORT		"30343"
+#define DEFAULT_PORT_TLS	"30344"
 
 /* Maximum message size (2Mb) */
 #define MESSAGE_SIZE_MAX	(2 * 1024 * 1024)

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -525,6 +525,26 @@ handle_suspend(CommandSuspend *msg, struct connection_closure *closure)
 }
 
 static bool
+handle_client_hello(ClientHello *msg, struct connection_closure *closure)
+{
+    debug_decl(handle_client_hello, SUDO_DEBUG_UTIL);
+
+    if (closure->state != INITIAL) {
+	sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
+	    "unexpected state %d", closure->state);
+	closure->errstr = _("state machine error");
+	debug_return_bool(false);
+    }
+
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: received ClientHello",
+	__func__);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: client ID %s",
+	__func__, msg->client_id);
+
+    debug_return_bool(true);
+}
+
+static bool
 handle_client_message(uint8_t *buf, size_t len,
     struct connection_closure *closure)
 {
@@ -575,6 +595,9 @@ handle_client_message(uint8_t *buf, size_t len,
 	break;
     case CLIENT_MESSAGE__TYPE_SUSPEND_EVENT:
 	ret = handle_suspend(msg->suspend_event, closure);
+	break;
+    case CLIENT_MESSAGE__TYPE_HELLO_MSG:
+	ret = handle_client_hello(msg->hello_msg, closure);
 	break;
     default:
 	sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -186,18 +186,6 @@ fmt_hello_message(struct connection_buffer *buf, bool tls)
 
     /* TODO: implement redirect and servers array.  */
     hello.server_id = (char *)server_id;
-#if defined(HAVE_OPENSSL)
-    if (tls) {
-	hello.tls = true;
-	hello.tls_server_auth = logsrvd_get_tls_config()->verify;
-	hello.tls_reqcert = logsrvd_get_tls_config()->check_peer;
-    } else
-#endif
-    {
-	hello.tls = false;
-	hello.tls_server_auth = false;
-	hello.tls_reqcert = false;
-    }
     msg.hello = &hello;
     msg.type_case = SERVER_MESSAGE__TYPE_HELLO;
 

--- a/logsrvd/logsrvd.h
+++ b/logsrvd/logsrvd.h
@@ -31,9 +31,6 @@
 
 #include "logsrv_util.h"
 
-/* Default listen address (port 30344 on all interfaces). */
-#define DEFAULT_LISTEN_ADDR	"*:" DEFAULT_PORT_STR
-
 /* Default timeout value for server socket */
 #define DEFAULT_SOCKET_TIMEOUT_SEC 30
 
@@ -102,6 +99,7 @@ struct connection_closure {
 #endif
     const char *errstr;
     struct iolog_file iolog_files[IOFD_MAX];
+    bool tls;
     bool read_instead_of_write;
     bool write_instead_of_read;
     bool temporary_write_event;
@@ -131,6 +129,7 @@ struct listen_address {
     char *sa_str;
     union sockaddr_union sa_un;
     socklen_t sa_len;
+    bool tls;
 };
 TAILQ_HEAD(listen_address_list, listen_address);
 
@@ -141,6 +140,7 @@ struct listener {
     TAILQ_ENTRY(listener) entries;
     struct sudo_event *ev;
     int sock;
+    bool tls;
 };
 TAILQ_HEAD(listener_list, listener);
 
@@ -199,7 +199,6 @@ bool logsrvd_conf_tcp_keepalive(void);
 const char *logsrvd_conf_pid_file(void);
 struct timespec *logsrvd_conf_get_sock_timeout(void);
 #if defined(HAVE_OPENSSL)
-bool logsrvd_conf_get_tls_opt(void);
 const struct logsrvd_tls_config *logsrvd_get_tls_config(void);
 struct logsrvd_tls_runtime *logsrvd_get_tls_runtime(void);
 #endif

--- a/logsrvd/logsrvd_conf.c
+++ b/logsrvd/logsrvd_conf.c
@@ -379,7 +379,7 @@ cb_listen_address(struct logsrvd_config *config, const char *str)
 {
     struct addrinfo hints, *res, *res0 = NULL;
     char *copy, *host, *port;
-    bool ret = false;
+    bool tls, ret = false;
     int error;
     debug_decl(cb_iolog_mode, SUDO_DEBUG_UTIL);
 
@@ -389,7 +389,8 @@ cb_listen_address(struct logsrvd_config *config, const char *str)
     }
 
     /* Parse host[:port] */
-    if (!sudo_parse_host_port(copy, &host, &port, DEFAULT_PORT_STR))
+    if (!sudo_parse_host_port(copy, &host, &port, &tls, DEFAULT_PORT_STR,
+	    DEFAULT_PORT_STR))
 	goto done;
     if (host[0] == '*' && host[1] == '\0')
 	host = NULL;

--- a/plugins/sudoers/def_data.c
+++ b/plugins/sudoers/def_data.c
@@ -530,6 +530,10 @@ struct sudo_defs_types sudo_defs_table[] = {
 	N_("Path to the sudoers private key file: %s"),
 	NULL,
     }, {
+	"log_server_verify", T_FLAG,
+	N_("Verify that the log server's certificate is valid"),
+	NULL,
+    }, {
 	"runas_allow_unknown_id", T_FLAG,
 	N_("Allow the use of unknown runas user and/or group ID"),
 	NULL,

--- a/plugins/sudoers/def_data.h
+++ b/plugins/sudoers/def_data.h
@@ -244,13 +244,15 @@
 #define def_log_server_peer_cert (sudo_defs_table[I_LOG_SERVER_PEER_CERT].sd_un.str)
 #define I_LOG_SERVER_PEER_KEY   122
 #define def_log_server_peer_key (sudo_defs_table[I_LOG_SERVER_PEER_KEY].sd_un.str)
-#define I_RUNAS_ALLOW_UNKNOWN_ID 123
+#define I_LOG_SERVER_VERIFY     123
+#define def_log_server_verify   (sudo_defs_table[I_LOG_SERVER_VERIFY].sd_un.flag)
+#define I_RUNAS_ALLOW_UNKNOWN_ID 124
 #define def_runas_allow_unknown_id (sudo_defs_table[I_RUNAS_ALLOW_UNKNOWN_ID].sd_un.flag)
-#define I_RUNAS_CHECK_SHELL     124
+#define I_RUNAS_CHECK_SHELL     125
 #define def_runas_check_shell   (sudo_defs_table[I_RUNAS_CHECK_SHELL].sd_un.flag)
-#define I_PAM_RUSER             125
+#define I_PAM_RUSER             126
 #define def_pam_ruser           (sudo_defs_table[I_PAM_RUSER].sd_un.flag)
-#define I_PAM_RHOST             126
+#define I_PAM_RHOST             127
 #define def_pam_rhost           (sudo_defs_table[I_PAM_RHOST].sd_un.flag)
 
 enum def_tuple {

--- a/plugins/sudoers/def_data.in
+++ b/plugins/sudoers/def_data.in
@@ -384,6 +384,9 @@ log_server_peer_cert
 log_server_peer_key
 	T_STR|T_BOOL|T_PATH
 	"Path to the sudoers private key file: %s"
+log_server_verify
+	T_FLAG
+	"Verify that the log server's certificate is valid"
 runas_allow_unknown_id
 	T_FLAG
 	"Allow the use of unknown runas user and/or group ID"

--- a/plugins/sudoers/defaults.c
+++ b/plugins/sudoers/defaults.c
@@ -568,6 +568,7 @@ init_defaults(void)
     def_compress_io = true;
 #endif
     def_log_server_timeout = 30;
+    def_log_server_verify = true;
     def_log_server_keepalive = true;
     def_ignore_audit_errors = true;
     def_ignore_iolog_errors = false;

--- a/plugins/sudoers/iolog_client.c
+++ b/plugins/sudoers/iolog_client.c
@@ -216,8 +216,10 @@ tls_init(struct client_closure *closure)
             if (SSL_CTX_load_verify_locations(closure->ssl_ctx,
                 closure->log_details->ca_bundle, NULL) <= 0) {
                 errstr = ERR_reason_error_string(ERR_get_error());
-                sudo_warnx(U_("Calling SSL_CTX_load_verify_locations() failed: %s"),
-                    errstr);
+                sudo_warnx(U_("%s: %s"), closure->log_details->ca_bundle,
+		    errstr);
+		sudo_warnx(U_("unable to load certificate authority bundle %s"),
+		    closure->log_details->ca_bundle);
                 goto bad;
             }
         }
@@ -229,8 +231,9 @@ tls_init(struct client_closure *closure)
         if (!SSL_CTX_use_certificate_chain_file(closure->ssl_ctx,
                 closure->log_details->cert_file)) {
             errstr = ERR_reason_error_string(ERR_get_error());
-            sudo_warnx(U_("Unable to load cert into the ssl context: %s"),
-                errstr);
+	    sudo_warnx(U_("%s: %s"), closure->log_details->cert_file, errstr);
+	    sudo_warnx(U_("unable to load certificate %s"),
+		closure->log_details->cert_file);
             goto bad;
         }
         if (closure->log_details->key_file == NULL) {
@@ -238,10 +241,12 @@ tls_init(struct client_closure *closure)
             closure->log_details->key_file = closure->log_details->cert_file;
         }
         if (!SSL_CTX_use_PrivateKey_file(closure->ssl_ctx,
-                closure->log_details->key_file, X509_FILETYPE_PEM)) {
+                closure->log_details->key_file, SSL_FILETYPE_PEM) ||
+                !SSL_CTX_check_private_key(closure->ssl_ctx)) {
             errstr = ERR_reason_error_string(ERR_get_error());
-            sudo_warnx(U_("Unable to load private key into the ssl context: %s"),
-                errstr);
+	    sudo_warnx(U_("%s: %s"), closure->log_details->key_file, errstr);
+	    sudo_warnx(U_("unable to load private key %s"),
+		closure->log_details->key_file);
             goto bad;
         }
     }

--- a/plugins/sudoers/iolog_client.c
+++ b/plugins/sudoers/iolog_client.c
@@ -215,11 +215,13 @@ log_server_connect(struct sudoers_str_list *servers, bool tcp_keepalive,
     char *copy, *host, *port;
     const char *cause = NULL;
     int sock = -1;
+    bool tls;
     debug_decl(restore_nproc, SUDOERS_DEBUG_UTIL);
 
     STAILQ_FOREACH(server, servers, entries) {
 	copy = strdup(server->str);
-	if (!sudo_parse_host_port(copy, &host, &port, DEFAULT_PORT_STR)) {
+	if (!sudo_parse_host_port(copy, &host, &port, &tls, DEFAULT_PORT_STR,
+		DEFAULT_PORT_STR)) {
 	    free(copy);
 	    continue;
 	}

--- a/plugins/sudoers/iolog_plugin.h
+++ b/plugins/sudoers/iolog_plugin.h
@@ -30,8 +30,9 @@
 # error protobuf-c version 1.30 or higher required
 #endif
 
-/* Default port to listen on */
-#define DEFAULT_PORT_STR	"30344"
+/* Default ports to listen on */
+#define DEFAULT_PORT		"30343"
+#define DEFAULT_PORT_TLS	"30344"
 
 /* Maximum message size (2Mb) */
 #define MESSAGE_SIZE_MAX	(2 * 1024 * 1024)
@@ -63,7 +64,6 @@ struct iolog_details {
     char **user_env;
     struct sudoers_str_list *log_servers;
     struct timespec server_timeout;
-    bool tcp_keepalive;
 #if defined(HAVE_OPENSSL)
     char *ca_bundle;
     char *cert_file;
@@ -72,6 +72,8 @@ struct iolog_details {
     int argc;
     int lines;
     int cols;
+    bool keepalive;
+    bool verify_server;
     bool ignore_iolog_errors;
 };
 
@@ -92,14 +94,13 @@ struct client_closure {
     bool read_instead_of_write;
     bool write_instead_of_read;
     bool temporary_write_event;
-    const struct sudoers_string *server_name;
+    char *server_name;
 #if defined(HAVE_STRUCT_IN6_ADDR)
     char server_ip[INET6_ADDRSTRLEN];
 #else
     char server_ip[INET_ADDRSTRLEN];
 #endif
 #if defined(HAVE_OPENSSL)
-    bool tls;
     SSL_CTX *ssl_ctx;
     SSL *ssl;
 #endif /* HAVE_OPENSSL */
@@ -117,41 +118,8 @@ struct client_closure {
     char *iolog_id;
 };
 
-#if defined(HAVE_OPENSSL)
-# define CLIENT_CLOSURE_INITIALIZER(_c)			\
-    {							\
-	-1,						\
-	false,						\
-	false,						\
-	false,						\
-	NULL,					    \
-	"", 					    \
-    false,                      \
-    NULL,						\
-    NULL,						\
-	ERROR,						\
-	false,						\
-	TAILQ_HEAD_INITIALIZER((_c).write_bufs),	\
-	TAILQ_HEAD_INITIALIZER((_c).free_bufs)		\
-    }
-#else
-# define CLIENT_CLOSURE_INITIALIZER(_c)			\
-    {							\
-	-1,						\
-	false,						\
-	false,						\
-	false,						\
-	NULL,					    \
-	"", 					    \
-	ERROR,						\
-	false,						\
-	TAILQ_HEAD_INITIALIZER((_c).write_bufs),	\
-	TAILQ_HEAD_INITIALIZER((_c).free_bufs)		\
-    }
-#endif /* HAVE_OPENSSL */
-
 /* iolog_client.c */
-bool client_closure_fill(struct client_closure *closure, int sock, const struct sudoers_string *host, struct timespec *now, struct iolog_details *details, struct io_plugin *sudoers_io);
+struct client_closure *client_closure_alloc(struct iolog_details *details, struct io_plugin *sudoers_io, struct timespec *now);
 bool client_close(struct client_closure *closure, int exit_status, int error);
 bool fmt_accept_message(struct client_closure *closure);
 bool fmt_client_message(struct client_closure *closure, ClientMessage *msg);
@@ -159,8 +127,8 @@ bool fmt_exit_message(struct client_closure *closure, int exit_status, int error
 bool fmt_io_buf(struct client_closure *closure, int type, const char *buf, unsigned int len, struct timespec *delay);
 bool fmt_suspend(struct client_closure *closure, const char *signame, struct timespec *delay);
 bool fmt_winsize(struct client_closure *closure, unsigned int lines, unsigned int cols, struct timespec *delay);
-int log_server_connect(struct sudoers_str_list *servers, bool tcp_keepalive, struct timespec *timo, struct sudoers_string **connected_server);
+bool log_server_connect(struct client_closure *closure);
 void client_closure_free(struct client_closure *closure);
-bool read_server_hello(int sock, struct client_closure *closure);
+bool read_server_hello(struct client_closure *closure);
 
 #endif /* SUDOERS_IOLOG_CLIENT_H */

--- a/plugins/sudoers/policy.c
+++ b/plugins/sudoers/policy.c
@@ -564,7 +564,7 @@ sudoers_policy_exec_setup(char *argv[], char *envp[], mode_t cmnd_umask,
 	debug_return_bool(true);	/* nothing to do */
 
     /* Increase the length of command_info as needed, it is *not* checked. */
-    command_info = calloc(53, sizeof(char *));
+    command_info = calloc(54, sizeof(char *));
     if (command_info == NULL)
 	goto oom;
 
@@ -749,7 +749,11 @@ sudoers_policy_exec_setup(char *argv[], char *envp[], mode_t cmnd_umask,
     }
 
     if ((command_info[info_len++] = sudo_new_key_val("log_server_keepalive",
-        def_log_server_keepalive ? "true" : "false")) == NULL)
+	    def_log_server_keepalive ? "true" : "false")) == NULL)
+        goto oom;
+
+    if ((command_info[info_len++] = sudo_new_key_val("log_server_verify",
+	    def_log_server_verify ? "true" : "false")) == NULL)
         goto oom;
 
     if (def_log_server_cabundle != NULL) {


### PR DESCRIPTION
For TLS connections we now do the TLS handshake immediately before the ServerHello message.  This lets the client receive an alert from the server is there is a handshake error after the TLS handshake has succeeded.  It also means that the contents of the ServerHello message are protected from a man-in-the-middle attack.  Non-TLS connections are now on port 30343 and the server listens on both 30343 and 30344 (TLS) by default.