### PR TITLE
Fix includes when building with musl

### DIFF
--- a/include/sudo_debug.h
+++ b/include/sudo_debug.h
@@ -25,6 +25,7 @@
 #else
 # include "compat/stdbool.h"
 #endif
+#include <sys/types.h>
 #include "sudo_queue.h"
 
 /*


### PR DESCRIPTION
`mode_t` and `id_t` are used in `sudo_debug.h`, but are undefined if building with
musl libc. Per the [<sys/types.h> spec] it seems it should be included.

[<sys/types.h> spec]: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/types.h.html