### PR TITLE
configure: Fix runstatedir handling for distros that do not support it

### DIFF
--- a/configure
+++ b/configure
@@ -26718,7 +26718,7 @@ EOF
 $as_echo_n "checking for sudo run dir location... " >&6; }
 if test -n "$with_rundir"; then
     rundir="$with_rundir"
-elif test "$runstatedir" != '${localstatedir}/run'; then
+elif test -n "$runstatedir" && test "$runstatedir" != '${localstatedir}/run'; then
     rundir="$runstatedir/sudo"
 else
     # No --with-rundir or --runstatedir specified

--- a/m4/sudo.m4
+++ b/m4/sudo.m4
@@ -120,7 +120,7 @@ dnl
 AC_DEFUN([SUDO_RUNDIR], [AC_MSG_CHECKING(for sudo run dir location)
 if test -n "$with_rundir"; then
     rundir="$with_rundir"
-elif test "$runstatedir" != '${localstatedir}/run'; then
+elif test -n "$runstatedir" && test "$runstatedir" != '${localstatedir}/run'; then
     rundir="$runstatedir/sudo"
 else
     # No --with-rundir or --runstatedir specified


### PR DESCRIPTION
runstatedir was added in yet-to-be released autoconf 2.70. Some distros are shipping this addition in their autoconf packages, but others, such as Fedora, are not. This causes the rundir variable to be set incorrectly if the configure script is regenerated with an unpatched autoconf since the runstatedir variable set is deleted after regeneration. This change works around that problem by checking that runstatedir is non-empty before potentially using it to set the rundir variable