### PR TITLE
lib/eventlog/Makefile.in: fix static build without closefrom

### DIFF
--- a/lib/eventlog/Makefile.in
+++ b/lib/eventlog/Makefile.in
@@ -46,8 +46,9 @@ LDFLAGS = @LDFLAGS@
 # Flags to pass to libtool
 LTFLAGS = @LT_STATIC@
 
-# Libraries for test programs
-LIBS = $(top_builddir)/lib/util/libsudo_util.la
+# Libraries
+LT_LIBS = $(top_builddir)/lib/util/libsudo_util.la
+LIBS = $(LT_LIBS)
 
 # Address sanitizer flags
 ASAN_CFLAGS = @ASAN_CFLAGS@
@@ -132,7 +133,7 @@ $(devdir)/log_server.pb-c.c: $(srcdir)/log_server.proto
 	fi
 
 libsudo_eventlog.la: $(LIBEVENTLOG_OBJS)
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LIBEVENTLOG_OBJS)
+	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LIBEVENTLOG_OBJS) $(LT_LIBS)
 
 check_wrap: $(CHECK_WRAP_OBJS) $(LIBUTIL)
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(CHECK_WRAP_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS)


### PR DESCRIPTION
Since version 1.9.4 and https://github.com/sudo-project/sudo/commit/bd1ca79cca827a92e904f022e49df121931d4ff5, when closefrom is not available, libsudo_eventlog.a depends on libsudo_util.a. So reflect this dependency in the libtool file to avoid the following static build failure of logsrvd:

```
/bin/bash ../libtool --tag=disable-static --mode=link /home/buildroot/autobuild/instance-1/output-1/host/bin/powerpc-linux-gcc -o sudo_logsrvd logsrv_util.o iolog_writer.o logsrvd.o logsrvd_conf.o -static -Wl,--enable-new-dtags -Wl,-z,relro    ../lib/iolog/libsudo_iolog.la ../lib/eventlog/libsudo_eventlog.la ../lib/logsrv/liblogsrv.la
/bin/bash ../libtool --tag=disable-static --mode=link /home/buildroot/autobuild/instance-1/output-1/host/bin/powerpc-linux-gcc -o sudo_sendlog logsrv_util.o sendlog.o -static -Wl,--enable-new-dtags -Wl,-z,relro    ../lib/iolog/libsudo_iolog.la ../lib/eventlog/libsudo_eventlog.la ../lib/logsrv/liblogsrv.la
libtool: link: /home/buildroot/autobuild/instance-1/output-1/host/bin/powerpc-linux-gcc -o sudo_logsrvd logsrv_util.o iolog_writer.o logsrvd.o logsrvd_conf.o -static -Wl,--enable-new-dtags -Wl,-z -Wl,relro  ../lib/iolog/.libs/libsudo_iolog.a /home/buildroot/autobuild/instance-1/output-1/build/sudo-1.9.5p1/lib/util/.libs/libsudo_util.a -lpthread -lz ../lib/eventlog/.libs/libsudo_eventlog.a ../lib/logsrv/.libs/liblogsrv.a
/home/buildroot/autobuild/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/powerpc-buildroot-linux-uclibc/8.3.0/../../../../powerpc-buildroot-linux-uclibc/bin/ld: ../lib/eventlog/.libs/libsudo_eventlog.a(eventlog.o): in function `send_mail.constprop.1':
eventlog.c:(.text+0x149c): undefined reference to `sudo_closefrom'
collect2: error: ld returned 1 exit status
```

Fixes:
 - http://autobuild.buildroot.org/results/515b45f876fa9de03c9235f86017f4dc10eb3b54

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>