### PR TITLE
stop manipulating the -s command string

### DIFF
--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -622,9 +622,6 @@ parse_args(int argc, char **argv, int *old_optind, int *nargc, char ***nargv,
 
 	    for (dst = cmnd, av = argv; *av != NULL; av++) {
 		for (src = *av; *src != '\0'; src++) {
-		    /* quote potential meta characters */
-		    if (!isalnum((unsigned char)*src) && *src != '_' && *src != '-' && *src != '$')
-			*dst++ = '\\';
 		    *dst++ = *src;
 		}
 		*dst++ = ' ';


### PR DESCRIPTION
This change does away with backslash-escaping most non-alphanumeric characters a user enters in CMD_STRING when they do `sudo -s "CMD_STRING"`

Before this change:
```
hostname$ sudo -s "whoami; echo \$USER; c++ --version"
/bin/bash: line 1: whoami; echo root; c++ --version: command not found
```
and `exec /bin/bash [/bin/bash -c whoami\;\ echo\ $USER\;\ c\+\+\ --version]` appears in sudo's debug log

And then after this change:
```
hostname$ sudo -s "whoami; echo \$USER; c++ --version"
root
root
c++ (GCC) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
and `exec /bin/bash [/bin/bash -c whoami; echo $USER; c++ --version]` appears in the sudo debug log

This fixes https://github.com/sudo-project/sudo/issues/78

This manipulation seems to be undocumented and is unexpected (to me anyway) and and I'm really interested to know what it's good for and why I might want a `\` to be inserted before the `+`s if for some reason I decided to call `c++` with `sudo -s`