### PR TITLE
Fix a tiny typo in the Sudo manpage

### DIFF
--- a/doc/sudo.man.in
+++ b/doc/sudo.man.in
@@ -236,7 +236,7 @@ authentication.
 .\}
 .TP 12n
 \fB\-B\fR, \fB\--bell\fR
-Ring the bell as part of the password promp when a terminal is present.
+Ring the bell as part of the password prompt when a terminal is present.
 This option has no effect if an askpass program is used.
 .TP 12n
 \fB\-b\fR, \fB\--background\fR

--- a/doc/sudo.mdoc.in
+++ b/doc/sudo.mdoc.in
@@ -233,7 +233,7 @@ This option is only available on systems that support
 authentication.
 .\}
 .It Fl B , -bell
-Ring the bell as part of the password promp when a terminal is present.
+Ring the bell as part of the password prompt when a terminal is present.
 This option has no effect if an askpass program is used.
 .It Fl b , -background
 Run the given command in the background.


### PR DESCRIPTION
This PR fixes a tiny typo I spotted in the manpage for `sudo`, a missing `t` on the end of `prompt` in the `-B` section. Not really important, but may as well be fixed.