### PR TITLE
Added forgoten declaration

### DIFF
--- a/plugins/sudoers/audit.c
+++ b/plugins/sudoers/audit.c
@@ -303,6 +303,13 @@ log_server_exit(int status_type, int status)
     debug_return;
 }
 #else
+static void
+audit_to_eventlog(struct eventlog *evlog, char * const command_info[],
+    char * const run_argv[], char * const run_envp[])
+{
+    return;
+}
+
 static bool
 log_server_accept(char * const command_info[], char * const run_argv[],
     char * const run_envp[])


### PR DESCRIPTION
It is not possible to build sudo with `--disable-log-client`. `audit_to_evenlog` symbol is missing. 