### PR TITLE
Process may hung when caller's SIGCHLD sets  SIG_IGN

### DIFF
--- a/src/exec_nopty.c
+++ b/src/exec_nopty.c
@@ -363,6 +363,7 @@ exec_nopty(struct command_details *details, struct command_status *cstat)
      */
     sigfillset(&set);
     sigprocmask(SIG_BLOCK, &set, &oset);
+    signal(SIGCHLD, SIG_DFL);
 
     /* Check for early termination or suspend signals before we fork. */
     if (sudo_terminated(cstat)) {


### PR DESCRIPTION
Process execute sudo command ignored SIGCHLD,
if the child exits immediately,there would no SIGCHLD.

Signed-off-by: ​JiangKun <jiang.kun2@zte.com.cn>