### PR TITLE
build: Use -module for sudo_noexec.la

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -175,15 +175,8 @@ Makefile: $(srcdir)/Makefile.in
 sudo: $(OBJS) $(LT_LIBS) @STATIC_SUDOERS@
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(OBJS) $(SUDO_LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS) @STATIC_SUDOERS@
 
-# We can't use -module here since you cannot preload a module on Darwin
-libsudo_noexec.la: sudo_noexec.lo
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) $(LDFLAGS) $(LT_LDFLAGS) $(SSP_LDFLAGS) @LIBDL@ -o $@ sudo_noexec.lo -avoid-version -rpath $(noexecdir) -shrext .so
-
-# Some hackery is required to install this as sudo_noexec, not libsudo_noexec
-sudo_noexec.la: libsudo_noexec.la
-	sed 's/libsudo_noexec/sudo_noexec/g' libsudo_noexec.la > sudo_noexec.la
-	if test -f .libs/libsudo_noexec.lai; then sed 's/libsudo_noexec/sudo_noexec/g' .libs/libsudo_noexec.lai > .libs/sudo_noexec.lai; fi
-	cp -p .libs/libsudo_noexec.so .libs/sudo_noexec.so
+sudo_noexec.la: sudo_noexec.lo
+	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) $(LDFLAGS) $(LT_LDFLAGS) $(SSP_LDFLAGS) @LIBDL@ -o $@ sudo_noexec.lo -avoid-version -rpath $(noexecdir) -module -shrext .so
 
 sesh: $(SESH_OBJS) $(LT_LIBS)
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(SESH_OBJS) $(LDFLAGS) $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(SSP_LDFLAGS) $(LIBS)


### PR DESCRIPTION
When building sudo with slibtool-0.5.34 or newer (https://dev.midipix.org/cross/slibtool) it will fail.
```
rdlibtool --tag=disable-static --mode=install /bin/sh ../scripts/install-sh -c -o 0 -g 0 -m 0644 sudo_noexec.la /tmp/delme/usr/local/libexec/sudo

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/sudo/src"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 31051}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 29805}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/sudo/libtool".
rdlibtool: error logged in slbt_exec_install_entry(), line 516: path not found: .libs/sudo_noexec.so.def.host.
rdlibtool: < returned to > slbt_exec_install(), line 875.
make[1]: *** [Makefile:243: install-noexec] Error 2
make[1]: Leaving directory '/tmp/sudo/src'
make: *** [Makefile:190: install] Error 2
```
This is because of sudo contains a hack for darwin which builds `libsudo_noexec.la` and then manually edits and renames the file to `sudo_noexec.la` instead of just compiling it with `-module`. Additionally due to unrelated bug fixes slibtool exposed this issue in the recent `0.5.34` release which now requires host information during install mode which will not be present with such a hack. Not to mention that manually editing and renaming `.la` files is entirely non-portable and only works with GNU libtool because it is an inactive project which is far less permissive than slibtool.

Unfortunately I do not have a darwin system to test, but if this is still a problem there I strongly suggest that a better solution is found on that platform.