### PR TITLE
lib: util: make mksig{list,name} tools paths configurable

### DIFF
--- a/lib/util/Makefile.in
+++ b/lib/util/Makefile.in
@@ -222,11 +222,13 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
 	    $(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(LDFLAGS) $(ASAN_LDFLAGS) $(SSP_LDFLAGS) $(LT_LDFLAGS) $(LTOBJS) -version-info $(SHLIB_VERSION) -rpath $(libexecdir)/sudo @LT_DEP_LIBS@ @LIBINTL@ @LIBMD@ @LIBPTHREAD@ @LIBDL@ @LIBRT@ @NET_LIBS@;; \
 	esac
 
+MKSIGTOOLSPATH ?= .
+
 siglist.c: mksiglist
-	./mksiglist > $@
+	$(MKSIGTOOLSPATH)/mksiglist > $@
 
 signame.c: mksigname
-	./mksigname > $@
+	$(MKSIGTOOLSPATH)/mksigname > $@
 
 mksiglist: $(srcdir)/mksiglist.c $(srcdir)/mksiglist.h $(incdir)/sudo_compat.h $(top_builddir)/config.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(srcdir)/mksiglist.c -o $@


### PR DESCRIPTION
When cross-compiling, the mksig{list,name} tools get built via the
host-side of the build, and then get installed into a local bin directory
to be run/used to generate the 'siglist.c' and 'signame.c' files for the
target build.

Naturally, the host-side builds and the target-side builds have different
folders, so running ./mksig{list,name} won't work.

To accommodate for this, we add a variable that can be overridden via
env-vars at build time to specify where these 2 tools are placed.
An absolute path can be specified as well, which is great for
cross-building as it can avoid any host-installed mksig{list,name} tools.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>