### PR TITLE
Fix bad getgroups() pattern

### DIFF
--- a/src/sesh.c
+++ b/src/sesh.c
@@ -399,16 +399,16 @@ sesh_sudoedit(int argc, char *argv[])
      */
     run_cred.uid = run_cred.euid = geteuid();
     run_cred.gid = run_cred.egid = getegid();
-    run_cred.ngroups = getgroups(0, NULL); // -V575
-    if (run_cred.ngroups > 0) {
-	run_cred.groups = reallocarray(NULL, run_cred.ngroups,
+    int ngroups = getgroups(0, NULL); // -V575
+    if (ngroups > 0) {
+	run_cred.groups = reallocarray(NULL, ngroups,
 	    sizeof(GETGROUPS_T));
 	if (run_cred.groups == NULL) {
 	    sudo_warnx(U_("%s: %s"), __func__,
 		U_("unable to allocate memory"));
 	    debug_return_int(SESH_ERR_FAILURE);
 	}
-	if (getgroups(run_cred.ngroups, run_cred.groups) < 0) {
+	if ((run_cred.ngroups = getgroups(ngroups, run_cred.groups)) < 0) {
 	    sudo_warn("%s", U_("unable to get group list"));
 	    debug_return_int(SESH_ERR_FAILURE);
 	}

--- a/src/sudo.c
+++ b/src/sudo.c
@@ -436,14 +436,14 @@ get_user_groups(const char *user, struct sudo_cred *cred)
 	    maxgroups = NGROUPS_MAX;
 
 	/* Note that macOS may return ngroups > NGROUPS_MAX. */
-	cred->ngroups = getgroups(0, NULL); // -V575
-	if (cred->ngroups > 0) {
+	int ngroups = getgroups(0, NULL); // -V575
+	if (ngroups > 0) {
 	    /* Use groups from kernel if not at limit or source is static. */
-	    if (cred->ngroups != maxgroups || group_source == GROUP_SOURCE_STATIC) {
-		cred->groups = reallocarray(NULL, cred->ngroups, sizeof(GETGROUPS_T));
+	    if (ngroups != maxgroups || group_source == GROUP_SOURCE_STATIC) {
+		cred->groups = reallocarray(NULL, ngroups, sizeof(GETGROUPS_T));
 		if (cred->groups == NULL)
 		    goto done;
-		if (getgroups(cred->ngroups, cred->groups) < 0) {
+		if ((cred->ngroups = getgroups(ngroups, cred->groups)) < 0) {
 		    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
 			"%s: unable to get %d groups via getgroups()",
 			__func__, cred->ngroups);

--- a/src/sudo_edit.c
+++ b/src/sudo_edit.c
@@ -81,15 +81,15 @@ set_tmpdir(struct sudo_cred *user_cred)
     saved_cred.euid = geteuid();
     saved_cred.gid = getgid();
     saved_cred.egid = getegid();
-    saved_cred.ngroups = getgroups(0, NULL); // -V575
-    if (saved_cred.ngroups > 0) {
+    int ngroups = getgroups(0, NULL); // -V575
+    if (ngroups > 0) {
 	saved_cred.groups =
-	    reallocarray(NULL, saved_cred.ngroups, sizeof(GETGROUPS_T));
+	    reallocarray(NULL, ngroups, sizeof(GETGROUPS_T));
 	if (saved_cred.groups == NULL) {
 	    sudo_warnx(U_("%s: %s"), __func__, U_("unable to allocate memory"));
 	    debug_return_bool(false);
 	}
-	if (getgroups(saved_cred.ngroups, saved_cred.groups) < 0) {
+	if ((saved_cred.ngroups = getgroups(ngroups, saved_cred.groups)) < 0) {
 	    sudo_warn("%s", U_("unable to get group list"));
 	    free(saved_cred.groups);
 	    debug_return_bool(false);


### PR DESCRIPTION
getgroups() is not guaranteed to return the same number of groups
between calls. Because groups are a flat namespace and group numbers
might collide if the system is subscribing to different directories,
some systems deduplicate groups with the same GID. The first call
should be used to retrieve the high watermark needed to allocate
the buffer, the second one should be used to retrieve the group
numbers as well as the actual number of groups we have been given.
Under certain circumstances, the current code causes sudo to read
uninitialized content present in the buffer.