### PR TITLE
Fix utmp resource leak

### DIFF
--- a/src/utmp.c
+++ b/src/utmp.c
@@ -210,6 +210,7 @@ utmp_login(const char *from_line, const char *to_line, int ttyfd,
 	memset(&utbuf, 0, sizeof(utbuf));
 	strncpy(utbuf.ut_line, from_line, sizeof(utbuf.ut_line));
 	ut_old = sudo_getutline(&utbuf);
+	sudo_setutent();
     }
     utmp_fill(to_line, user, ut_old, &utbuf);
     if (sudo_pututline(&utbuf) != NULL)


### PR DESCRIPTION
When writing to utmp sudo_pututline() finds a suitable place to write the new utmp entry but does so after the current file position. sudo_getutline() will advance the file position while it's searching for the matching entry. In some cases there might be a pty but no matching entry for it in utmp i.e. `screen -ln`. This will advance the file offset to the end of the file and sudo_pututline() will just extend utmp and append an entry. For workloads that frequently call sudo this can lead to unbounded growth and substantial latency for anything that has to search the massive utmp file. Calling setutxent() again while it still has a fd open will seek to the beginning of the file and reuse a previous matching entry. This can be non-trivial to reproduce but looking at the output of utmpdump will show spurious DEAD_PROCESS entries that match previous entries that should have been reused.