### PR TITLE
lib: util: Makefile.in: use host CFLAGS and CPPFLAGS for mksig{name,list}

### DIFF
--- a/lib/util/Makefile.in
+++ b/lib/util/Makefile.in
@@ -233,10 +233,10 @@ signame.c: mksigname
 	./mksigname > $@
 
 mksiglist: $(srcdir)/mksiglist.c mksiglist.h $(incdir)/sudo_compat.h $(top_builddir)/config.h
-	$(HOSTCC) $(CPPFLAGS) $(CFLAGS) $(srcdir)/mksiglist.c -o $@
+	$(HOSTCC) $(HOSTCPPFLAGS) $(HOSTCFLAGS) $(srcdir)/mksiglist.c -o $@
 
 mksigname: $(srcdir)/mksigname.c mksigname.h $(incdir)/sudo_compat.h $(top_builddir)/config.h
-	$(HOSTCC) $(CPPFLAGS) $(CFLAGS) $(srcdir)/mksigname.c -o $@
+	$(HOSTCC) $(HOSTCPPFLAGS) $(HOSTCFLAGS) $(srcdir)/mksigname.c -o $@
 
 $(srcdir)/sys_siglist.h: $(srcdir)/siglist.in
 	@if [ -n "$(DEVEL)" ]; then \


### PR DESCRIPTION
When cross-build support was added for mkig{name,list} was added, the
CFLAGS and CPPFLAGS should have been updated to the HOSTCFLAGS/HOSTCPPFLAGS
vars.

In a cross-build scenario, some of these flags don't match what the
compiler can understand (because they may be architecture specific) and
may fail the build.

Using the HOSTCFLAGS/HOSTCPPFLAGS works and builds successfully.
Also the output binary works on the target.

This is in continuation of
- https://github.com/sudo-project/sudo/pull/104
- https://github.com/sudo-project/sudo/pull/109

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>