### PR TITLE
Define MAP_FAILED where relevant if undefined

### DIFF
--- a/lib/util/getentropy.c
+++ b/lib/util/getentropy.c
@@ -76,6 +76,10 @@
 # define MAP_ANON MAP_ANONYMOUS
 #endif
 
+#ifndef MAP_FAILED
+# define MAP_FAILED ((void *) -1)
+#endif
+
 #define REPEAT 5
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 

--- a/lib/util/regress/mktemp/mktemp_test.c
+++ b/lib/util/regress/mktemp/mktemp_test.c
@@ -31,6 +31,10 @@
 # endif
 #endif
 
+#ifndef MAP_FAILED
+# define MAP_FAILED ((void *) -1)
+#endif
+
 #define MAX_TEMPLATE_LEN	10
 #define MAX_TRIES		100
 #define MIN_Xs			6

--- a/lib/util/snprintf.c
+++ b/lib/util/snprintf.c
@@ -116,6 +116,10 @@ static int xxxprintf(char **, size_t, int, const char *, va_list);
 # define MAP_ANON MAP_ANONYMOUS
 #endif
 
+#ifndef MAP_FAILED
+# define MAP_FAILED ((void *) -1)
+#endif
+
 /*
  * Allocate "size" bytes via mmap.
  */


### PR DESCRIPTION
On systems such as HP-UX 10.20, MAP_FAILED is not defined.