### PR TITLE
lib/util/mksigname.c: correctly include header for out of tree builds

### DIFF
--- a/lib/util/mksigname.c
+++ b/lib/util/mksigname.c
@@ -36,7 +36,7 @@ main(int argc, char *argv[])
 {
     unsigned int i;
 
-#include "mksigname.h"
+#include "lib/util/mksigname.h"
 
     printf("const char *const sudo_sys_signame[] = {\n");
     for (i = 0; i < nitems(sudo_sys_signame); i++) {


### PR DESCRIPTION
Signed-off-by: Alexander Kanavin <alex@linutronix.de>