### PR TITLE
Allow sudo -g anyone and sudo -u anyone -g anytwo

### DIFF
--- a/plugins/sudoers/sudoers.in
+++ b/plugins/sudoers/sudoers.in
@@ -76,21 +76,21 @@
 ##
 ## User privilege specification
 ##
-root ALL=(ALL) ALL
+root ALL=(ALL:ALL) ALL
 
 ## Uncomment to allow members of group wheel to execute any command
-# %wheel ALL=(ALL) ALL
+# %wheel ALL=(ALL:ALL) ALL
 
 ## Same thing without a password
-# %wheel ALL=(ALL) NOPASSWD: ALL
+# %wheel ALL=(ALL:ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
-# %sudo	ALL=(ALL) ALL
+# %sudo	ALL=(ALL:ALL) ALL
 
 ## Uncomment to allow any user to run sudo if they know the password
 ## of the user they are running the command as (root by default).
 # Defaults targetpw  # Ask for the password of the target user
-# ALL ALL=(ALL) ALL  # WARNING: only use this together with 'Defaults targetpw'
+# ALL ALL=(ALL:ALL) ALL  # WARNING: only use this together with 'Defaults targetpw'
 
 ## Read drop-in files from @sysconfdir@/sudoers.d
 @includedir @sysconfdir@/sudoers.d


### PR DESCRIPTION
When only the user (ALL) is specified explicitly, and the group is implied, only sudo -u works. Specifying both the user and group, like (ALL:ALL), is required to:

1) Use sudo -g by itself (with no -u user)
2) Use sudo -u and -g together, with a -g group that is different from the -u user's primary group