### PR TITLE
Do not unset user timeout when no default timeout is set.

### DIFF
--- a/plugins/sudoers/policy.c
+++ b/plugins/sudoers/policy.c
@@ -836,7 +836,7 @@ sudoers_policy_store_result(bool accepted, char *argv[], char *envp[],
 
     if (def_command_timeout > 0 || user_timeout > 0) {
 	int timeout = user_timeout;
-	if (timeout == 0 || def_command_timeout < timeout)
+    if (timeout == 0 || (def_command_timeout > 0 && def_command_timeout < timeout))
 	    timeout = def_command_timeout;
 	if (asprintf(&command_info[info_len++], "timeout=%u", timeout) == -1)
 	    goto oom;


### PR DESCRIPTION
When no default timeout is set in /etc/sudoers, the def_command_timeout variable
is set to 0 and then in sudoers_policy_store_result is considered to be smaller than
whatever the user specified on the command line (via the -T option), even though 0
in this case should be considered infinity.

I reproduced with sudo 1.9.5, but current version should be affected too. Without this patch:

```
germ61:~ # grep timeout /etc/sudoers
Defaults user_command_timeouts
germ61:~ # time sudo -T 5 sleep 10

real	0m10.109s
user	0m0.033s
sys	0m0.073s
```

With the patch:

```
germ61:~ # grep timeout /etc/sudoers
Defaults user_command_timeouts
germ61:~ # time sudo -T 5 sleep 10
Hangup

real	0m5.087s
user	0m0.026s
sys	0m0.062s
```