### PR TITLE
Edit to the sudo lecture

### DIFF
--- a/plugins/sudoers/check.c
+++ b/plugins/sudoers/check.c
@@ -293,7 +293,8 @@ display_lecture(struct sudo_conv_callback *callback)
 	"Administrator. It usually boils down to these three things:\n\n"
 	"    #1) Respect the privacy of others.\n"
 	"    #2) Think before you type.\n"
-	"    #3) With great power comes great responsibility.\n\n");
+	"    #3) With great power comes great responsibility.\n\n"
+	"For security reasons, the password you type is invisible.\n\n");
     sudo_conv(1, &msg, &repl, NULL);
 
 done:


### PR DESCRIPTION
Adding a short message to the lecture to make it easier and more understandable for first-time users to enter a password in a terminal.

Since the option to show asterisks when typing could be enabled, the sentence could be replaced with:
For security reasons, the password you type may be invisible.