### PR TITLE
Fix typo in sudoers comment

### DIFF
--- a/plugins/sudoers/sudoers.in
+++ b/plugins/sudoers/sudoers.in
@@ -64,7 +64,7 @@
 ##
 ## Uncomment to enable logging of a command's output, except for
 ## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
-## Sudo will create up to 2,176,782,336 I/O logs before recycing them.
+## Sudo will create up to 2,176,782,336 I/O logs before recycling them.
 ## Set maxseq to a smaller number if you don't have unlimited disk space.
 # Defaults log_output
 # Defaults!/usr/bin/sudoreplay !log_output


### PR DESCRIPTION
Fix a typo in the sudoers comment about `maxseq` param.

Introduced by 906eb19ece47023c659b4b3db2e7a6bb57dff0d9 in 1.9.11.