### PR TITLE
Add XDG_CURRENT_DESKTOP to initial_keepenv_table

### DIFF
--- a/plugins/sudoers/env.c
+++ b/plugins/sudoers/env.c
@@ -224,6 +224,7 @@ static const char *initial_keepenv_table[] = {
     "PS2",
     "XAUTHORITY",
     "XAUTHORIZATION",
+    "XDG_CURRENT_DESKTOP",
     NULL
 };
 


### PR DESCRIPTION
Qt needs `XDG_CURRENT_DESKTOP` to be set to determine the correct theme.

Since `DISPLAY` and `XAUTHORITY` are already in the default table of variables to preserve in the environment, just add `XDG_CURRENT_DESKTOP` to it.

Bug: https://launchpad.net/bugs/1958055