### PR TITLE
visudo.c: add nvim (Neovim) to lineno_editor list

### DIFF
--- a/plugins/sudoers/visudo.c
+++ b/plugins/sudoers/visudo.c
@@ -419,6 +419,7 @@ static const char *lineno_editors[] = {
     "vi",
     "nvi",
     "vim",
+    "nvim",
     "elvis",
     "*macs",
     "mg",


### PR DESCRIPTION
Neovim [supports it](https://neovim.io/doc/user/starting.html#-+).