### PR TITLE
iolog/hostcheck: These two parameters do not need to be initialized a…

### DIFF
--- a/lib/iolog/hostcheck.c
+++ b/lib/iolog/hostcheck.c
@@ -188,7 +188,7 @@ matches_common_name(const char *hostname, const char *ipaddr, const X509 *cert, 
 {
 	X509_NAME_ENTRY *common_name_entry = NULL;
 	ASN1_STRING *common_name_asn1 = NULL;
- 	int common_name_loc = -1;
+ 	int common_name_loc;
 	debug_decl(matches_common_name, SUDO_DEBUG_UTIL);
 
 	/* Find the position of the CN field in the Subject field of the certificate */
@@ -268,7 +268,7 @@ matches_subject_alternative_name(const char *hostname, const char *ipaddr, const
 {
     HostnameValidationResult result = MatchNotFound;
     int i;
-    int san_names_nb = -1;
+    int san_names_nb;
     STACK_OF(GENERAL_NAME) *san_names = NULL;
     debug_decl(matches_subject_alternative_name, SUDO_DEBUG_UTIL);
 

--- a/lib/protobuf-c/protobuf-c.c
+++ b/lib/protobuf-c/protobuf-c.c
@@ -1392,38 +1392,38 @@ repeated_field_pack(const ProtobufCFieldDescriptor *field,
 			break;
 		case PROTOBUF_C_TYPE_ENUM:
 		case PROTOBUF_C_TYPE_INT32: {
-			const int32_t *arr = (const int32_t *) array;
+			const int32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += int32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_SINT32: {
-			const int32_t *arr = (const int32_t *) array;
+			const int32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += sint32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_SINT64: {
-			const int64_t *arr = (const int64_t *) array;
+			const int64_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += sint64_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_UINT32: {
-			const uint32_t *arr = (const uint32_t *) array;
+			const uint32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += uint32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_INT64:
 		case PROTOBUF_C_TYPE_UINT64: {
-			const uint64_t *arr = (const uint64_t *) array;
+			const uint64_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += uint64_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_BOOL: {
-			const protobuf_c_boolean *arr = (const protobuf_c_boolean *) array;
+			const protobuf_c_boolean *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += boolean_pack(arr[i], payload_at);
 			break;

--- a/lib/util/arc4random.c
+++ b/lib/util/arc4random.c
@@ -150,7 +150,7 @@ _rs_rekey(unsigned char *dat, size_t datlen)
 static inline void
 _rs_random_buf(void *_buf, size_t n)
 {
-	unsigned char *buf = (unsigned char *)_buf;
+	unsigned char *buf = _buf;
 	unsigned char *keystream;
 	size_t m;
 


### PR DESCRIPTION
Signed-off-by: Li zeming <zeming@nfschina.com>

These two parameters do not need to be initialized and assigned, and the following code will only use them after assigning them directly.