### PR TITLE
Fix incorrect SHA384/512 digest calculation.

### DIFF
--- a/lib/util/sha2.c
+++ b/lib/util/sha2.c
@@ -490,7 +490,7 @@ SHA512Pad(SHA2_CTX *ctx)
 	SHA512Update(ctx, (uint8_t *)"\200", 1);
 
 	/* Pad message such that the resulting length modulo 1024 is 896. */
-	while ((ctx->count[0] & 1008) != 896)
+	while ((ctx->count[0] & 1016) != 896)
 		SHA512Update(ctx, (uint8_t *)"\0", 1);
 
 	/* Append length of message in bits and do final SHA512Transform(). */


### PR DESCRIPTION
Resolves an issue where certain message sizes result in an incorrect
checksum. Specifically, when:
(n*8) mod 1024 == 896
where n is the file size in bytes.