### PR TITLE
env_hooks: The val pointer variable is only used to return NULL

### DIFF
--- a/lib/protobuf-c/protobuf-c.c
+++ b/lib/protobuf-c/protobuf-c.c
@@ -1408,38 +1408,38 @@ repeated_field_pack(const ProtobufCFieldDescriptor *field,
 			break;
 		case PROTOBUF_C_TYPE_ENUM:
 		case PROTOBUF_C_TYPE_INT32: {
-			const int32_t *arr = (const int32_t *) array;
+			const int32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += int32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_SINT32: {
-			const int32_t *arr = (const int32_t *) array;
+			const int32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += sint32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_SINT64: {
-			const int64_t *arr = (const int64_t *) array;
+			const int64_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += sint64_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_UINT32: {
-			const uint32_t *arr = (const uint32_t *) array;
+			const uint32_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += uint32_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_INT64:
 		case PROTOBUF_C_TYPE_UINT64: {
-			const uint64_t *arr = (const uint64_t *) array;
+			const uint64_t *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += uint64_pack(arr[i], payload_at);
 			break;
 		}
 		case PROTOBUF_C_TYPE_BOOL: {
-			const protobuf_c_boolean *arr = (const protobuf_c_boolean *) array;
+			const protobuf_c_boolean *arr = array;
 			for (i = 0; i < count; i++)
 				payload_at += boolean_pack(arr[i], payload_at);
 			break;

--- a/src/env_hooks.c
+++ b/src/env_hooks.c
@@ -60,11 +60,9 @@ getenv_unhooked(const char *name)
 sudo_dso_public char *
 getenv(const char *name)
 {
-    char *val = NULL;
-
     switch (process_hooks_getenv(name, &val)) {
 	case SUDO_HOOK_RET_STOP:
-	    return val;
+	    return NULL;
 	case SUDO_HOOK_RET_ERROR:
 	    return NULL;
 	default:

--- a/src/load_plugins.c
+++ b/src/load_plugins.c
@@ -174,7 +174,7 @@ static struct plugin_container *
 new_container(void *handle, const char *path, struct generic_plugin *plugin,
     struct plugin_info *info)
 {
-    struct plugin_container *container = NULL;
+    struct plugin_container *container;
     debug_decl(new_container, SUDO_DEBUG_PLUGIN);
 
     if ((container = calloc(1, sizeof(*container))) == NULL) {


### PR DESCRIPTION
I found some code that can be optimized:
   remove type cast.
   remove initial assignment.
   delete unnecessary pointer variables.