### PR TITLE
Enforce SELinux type and role in sudoers. (proof of concept)

### DIFF
--- a/docs/sudoers.mdoc.in
+++ b/docs/sudoers.mdoc.in
@@ -1470,6 +1470,12 @@ specified in
 A role or type specified on the command line,
 however, will supersede the values in
 .Em sudoers .
+To prevent this behavior, prefix the SELinux role and/or type with an
+asterisk in this fashion:
+.Bd -literal
+auditor ALL = (root) TYPE=*auditor.process ROLE=*unconfined_r NOPASSWD: /usr/bin/bash
+.Ed
+
 .\}
 .if \n(AA \{\
 .Ss AppArmor_Spec

--- a/plugins/sudoers/parse.c
+++ b/plugins/sudoers/parse.c
@@ -221,7 +221,10 @@ apply_cmndspec(struct cmndspec *cs)
 	/* Set role and type if not specified on command line. */
 	if (user_role == NULL) {
 	    if (cs->role != NULL) {
-		user_role = strdup(cs->role);
+		if (cs->role[0] == '*')
+		    user_role = strdup(cs->role+1);
+		else
+		    user_role = strdup(cs->role);
 		if (user_role == NULL) {
 		    sudo_warnx(U_("%s: %s"), __func__,
 			U_("unable to allocate memory"));
@@ -235,10 +238,17 @@ apply_cmndspec(struct cmndspec *cs)
 		sudo_debug_printf(SUDO_DEBUG_INFO|SUDO_DEBUG_LINENO,
 		    "user_role -> %s", user_role);
 	    }
+	} else if (cs->role != NULL && cs->role[0] == '*') {
+	    sudo_warnx(U_("%s: %s"), __func__,
+			U_("cannot change the selinux role"));
+	    debug_return_bool(false);
 	}
 	if (user_type == NULL) {
 	    if (cs->type != NULL) {
-		user_type = strdup(cs->type);
+		if (cs->type[0] == '*')
+		    user_type = strdup(cs->type+1);
+		else
+		    user_type = strdup(cs->type);
 		if (user_type == NULL) {
 		    sudo_warnx(U_("%s: %s"), __func__,
 			U_("unable to allocate memory"));
@@ -252,6 +262,10 @@ apply_cmndspec(struct cmndspec *cs)
 		sudo_debug_printf(SUDO_DEBUG_INFO|SUDO_DEBUG_LINENO,
 		    "user_type -> %s", user_type);
 	    }
+	} else if (cs->type != NULL && cs->type[0] == '*') {
+	    sudo_warnx(U_("%s: %s"), __func__,
+			U_("cannot change the selinux type"));
+	    debug_return_bool(false);
 	}
 #endif /* HAVE_SELINUX */
 #ifdef HAVE_APPARMOR


### PR DESCRIPTION
At the moment a SELinux type and role can be defined in a sudoers file.
They help confined users who want to elevate privileges to a confined
administrator role: they can just type ```sudo``` without adding
```--role``` and ```--type``` on the command line. The command line
arguments take precedence over the values in the sudoers though.

Now outside the SELinux login world, considering a usecase where admins
need to grant some privileges to normal users, they will need to
carefully craft the right sudo rules. The command provided to the user
will run in an unconfined SELinux context, with all the root
capabilities, so the glob or regexp pattern must be written with no
mistake. The NOEXEC tag helps mitigating errors but is limited to
blocking execve system calls.

It should be possible to leverage SELinux: by enforcing the role and
type provided in the sudoers file, and writing a custom SELinux policy
module, I find that it is possible to give a normal, not confined user,
rights to run commands in a specific SELinux context, greatly reducing
the error surface.

Here is an example of such module (mostly copy pasted from what Udica
generates for containers):

```
(block auditor
(type process)
(type socket)
(roletype system_r process)
(typeattributeset domain (process ))
(typeattributeset container_domain (process ))
(typeattributeset svirt_sandbox_domain (process ))
(typeattributeset mcs_constrained_type (process ))
(typeattributeset file_type (socket ))
(allow process socket (sock_file (create open getattr setattr read write
rename link unlink ioctl lock append)))
(allow process proc_type (file (getattr open read)))
(allow process cpu_online_t (file (getattr open read)))
)
```

That can be installed with
```
semodule -i auditor.cil
```

To make sudo behavior backward compatible, in this proof of concept we
prefix the type and role with an asterisk to indicate it should take
precedence over arguments given on the command line. The sudoers ends up
looking like this:

```
auditor ALL = (root) TYPE=*auditor.process ROLE=*unconfined_r NOPASSWD: /usr/bin/bash
```

We observe the impact of this policy as files like /etc/passwd or
/etc/shadow are unreadable.

This is just a proof of concept wrote after briefly researching the subject. Maybe I missed something more fundamental. Also maybe it is possible to write an approval plugin to achieve the same behavior, but I had [some troubles](https://bugzilla.redhat.com/show_bug.cgi?id=2124005) getting the Python plugin framework to work on Fedora so I did that instead... Feedback welcome!