### PR TITLE
[cvtsudoers]: Prevent sudo from reading into undefined memory

### DIFF
--- a/plugins/sudoers/parse_ldif.c
+++ b/plugins/sudoers/parse_ldif.c
@@ -688,7 +688,7 @@ sudoers_parse_ldif(struct sudoers_parse_tree *parse_tree,
 		if (strncasecmp(attr, "cn=", 3) == 0) {
 		    for (attr += 3; *attr != '\0'; attr++) {
 			/* Handle escaped ',' chars. */
-			if (*attr == '\\')
+			if (*attr == '\\' && attr[1] != '\0')
 			    attr++;
 			if (*attr == ',') {
 			    attr++;


### PR DESCRIPTION
For the following piece of code:
https://github.com/sudo-project/sudo/blob/9f948224acb911cbec1ed9041887c1fe62c59877/plugins/sudoers/parse_ldif.c#L689-L698
`sudo` appears to be reading until it encounters a comma character or a null byte. However, in the case where it encounters something line similar to `dn:cn=sudo\`, sudo will keep reading beyond the null byte into unitialized memory/neighbouring buffers. This could lead to unexpected behaviour especially if the adjacent buffer contains the same string as that defined in `sudoers_base`.