### PR TITLE
[snprintf] Check for '\0' to prevent undef memory read

### DIFF
--- a/lib/util/snprintf.c
+++ b/lib/util/snprintf.c
@@ -1154,6 +1154,8 @@ __find_arguments(const char *fmt0, va_list ap, union arg **argtable)
 	for (;;) {
 		for (cp = fmt; (ch = *fmt) != '\0' && ch != '%'; fmt++)
 			/* void */;
+		if ( ch == '\0' )
+			goto done;
 		fmt++;		/* skip over '%' */
 
 		flags = 0;


### PR DESCRIPTION
I don't think this particular code-block is currently reachable since I am not able to get a reproducible crash for this.

 However, it seems like the following peice of code at:
 https://github.com/sudo-project/sudo/blob/e707ffe58b3ccfe5c72f54c38eac1d7069d5021e/lib/util/snprintf.c#L1155-L1162
allows the program to read beyond a null-byte in a string into undefined memory. 

The for loop in the code will terminate if it reaches a null-byte or a '%' character. However, immediately after, the character is unconditionally being skipped and the program keeps on executing regardless of whether or not it encountered a null-byte.