### PR TITLE
add fix for segfault introduced by issue #134

### DIFF
--- a/plugins/sudoers/match.c
+++ b/plugins/sudoers/match.c
@@ -118,9 +118,11 @@ userlist_matches(struct sudoers_parse_tree *parse_tree, const struct passwd *pw,
     int matched = UNSPEC;
     debug_decl(userlist_matches, SUDOERS_DEBUG_MATCH);
 
-    TAILQ_FOREACH_REVERSE(m, list, member_list, entries) {
-	if ((matched = user_matches(parse_tree, pw, m)) != UNSPEC)
-	    break;
+    if (list) {
+	TAILQ_FOREACH_REVERSE(m, list, member_list, entries) {
+	    if ((matched = user_matches(parse_tree, pw, m)) != UNSPEC)
+		break;
+	}
     }
     debug_return_int(matched);
 }


### PR DESCRIPTION
This change to the userlist_matches function in plugins/sudoers/match.c checks that there actually is a list to check. Since sssd seems to return NULL pointers for runas user lists, this prevents the null pointer dereference that causes a segmentation fault in the 'sudo -l -U <someuser>' command when sssd is in use. And checking function arguments is good practice anyway.

This patch does not address the issue that it could be a good idea to be able to list some user's commands without being able to execute any commands. I think a better way to address what issue #134 tried to do is to associate sudo -l with a "virtual command" for which it is possible to create rules. Then one could create a rule that allows to run this "virtual list command" as any user without allowing to run any other commands as this user.