### PR TITLE
Prevent integer underflow due to environment variable

### DIFF
--- a/plugins/sudoers/env.c
+++ b/plugins/sudoers/env.c
@@ -1278,7 +1278,7 @@ env_file_next_local(void *cookie, int *errnum)
 	val_len = strlen(++val);
 
 	/* Strip leading and trailing single/double quotes */
-	if ((val[0] == '\'' || val[0] == '\"') && val[0] == val[val_len - 1]) {
+	if ((val[0] == '\'' || val[0] == '\"') && val[0] == val[val_len - 1] && val_len > 1) {
 	    val[val_len - 1] = '\0';
 	    val++;
 	    val_len -= 2;


### PR DESCRIPTION
When the following line is encountered in a `/etc/environment` style file:
```
ENV_NAME='
```
the following code:
https://github.com/sudo-project/sudo/blob/8b5037a2117a0f03c34008514469bac22ff99490/plugins/sudoers/env.c#L1281-L1285
allows `val_len` to be set to -1 (since it assumes a closing end quote which will not be present).

Currently the underflowed value does not cause issues due to the surrounding code adding 1 to `val_len` whenever it is used, however it could become a issue later on if the code is moved around.
