### PR TITLE
Replace the Debian libselinux1 dependency with libapparmor1

### DIFF
--- a/etc/sudo.pp
+++ b/etc/sudo.pp
@@ -315,7 +315,7 @@ still allow people to get their work done."
 %endif
 
 %depend [deb]
-	libc6, libpam0g, libpam-modules, zlib1g, libselinux1
+	libc6, libpam0g, libpam-modules, zlib1g, libapparmor1
 
 %fixup [deb]
 	# Add Conflicts, Replaces headers and add libldap dependency as needed.


### PR DESCRIPTION
Debian >= 10 uses AppArmor by default instead of SELinux, so SELinux-related sudo features are typically going to be unusable in Debian installs. This changes the dependency on libselinux1 to be a dependency on libapparmor1 for .deb packages built with `make package`.