### PR TITLE
Prefer size_t over int, as casting can take extra instructions

### DIFF
--- a/lib/eventlog/parse_json.c
+++ b/lib/eventlog/parse_json.c
@@ -165,7 +165,7 @@ static char **
 json_array_to_strvec(struct eventlog_json_object *array)
 {
     struct json_item *item;
-    int len = 0;
+    size_t len = 0;
     char **ret;
     debug_decl(json_array_to_strvec, SUDO_DEBUG_UTIL);
 

--- a/lib/util/sudo_debug.c
+++ b/lib/util/sudo_debug.c
@@ -589,10 +589,10 @@ sudo_debug_exit_str_masked_v1(const char *func, const char *file, int line,
     int subsys, const char *ret)
 {
     static const char stars[] = "********************************************************************************";
-    int len = ret ? strlen(ret) : sizeof("(null)") - 1;
+    size_t len = ret ? strlen(ret) : sizeof("(null)") - 1;
 
     sudo_debug_printf2(NULL, NULL, 0, subsys | SUDO_DEBUG_TRACE,
-	"<- %s @ %s:%d := %.*s", func, file, line, len, ret ? stars : "(null)");
+	"<- %s @ %s:%zu := %.*s", func, file, line, len, ret ? stars : "(null)");
 }
 
 void

--- a/plugins/sudoers/fmtsudoers.c
+++ b/plugins/sudoers/fmtsudoers.c
@@ -259,7 +259,7 @@ sudoers_format_cmndspec(struct sudo_lbuf *lbuf,
 	char buf[sizeof("CCYYMMDDHHMMSSZ")] = "";
 	struct tm gmt;
 	if (gmtime_r(&cs->notbefore, &gmt) != NULL) {
-	    int len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
+	    size_t len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
 	    if (len != 0 && buf[sizeof(buf) - 1] == '\0')
 		sudo_lbuf_append(lbuf, "NOTBEFORE=%s ", buf);
 	}
@@ -268,7 +268,7 @@ sudoers_format_cmndspec(struct sudo_lbuf *lbuf,
 	char buf[sizeof("CCYYMMDDHHMMSSZ")] = "";
 	struct tm gmt;
 	if (gmtime_r(&cs->notafter, &gmt) != NULL) {
-	    int len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
+	    size_t len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
 	    if (len != 0 && buf[sizeof(buf) - 1] == '\0')
 		sudo_lbuf_append(lbuf, "NOTAFTER=%s ", buf);
 	}


### PR DESCRIPTION
It does not hurt when the functions that take the variable later on as an argument also expect them to be size_t.