### PR TITLE
digest_type should be unsigned, not signed

### DIFF
--- a/plugins/sudoers/parse.h
+++ b/plugins/sudoers/parse.h
@@ -435,7 +435,7 @@ time_t parse_gentime(const char *expstr);
 unsigned char *sudo_filedigest(int fd, const char *file, int digest_type, size_t *digest_len);
 
 /* digestname.c */
-const char *digest_type_to_name(int digest_type);
+const char *digest_type_to_name(unsigned int digest_type);
 
 /* parse.c */
 struct sudo_nss_list;

--- a/plugins/sudoers/regress/parser/check_digest.c
+++ b/plugins/sudoers/regress/parser/check_digest.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
     unsigned char *digest;
     unsigned int i, j;
     size_t digest_len;
-    int digest_type;
+    unsigned int digest_type;
 
     initprogname(argc > 0 ? argv[0] : "check_digest");
 


### PR DESCRIPTION
This also helps avoid platform-specific implementations of converting signed to unsigned numbers.