### PR TITLE
nbytes should be compared against INT_MAX, not UINT_MAX

### DIFF
--- a/lib/iolog/iolog_gets.c
+++ b/lib/iolog/iolog_gets.c
@@ -49,7 +49,7 @@ iolog_gets(struct iolog_file *iol, char *buf, size_t nbytes,
     char *str;
     debug_decl(iolog_gets, SUDO_DEBUG_UTIL);
 
-    if (nbytes > UINT_MAX) {
+    if (nbytes > INT_MAX) {
 	errno = EINVAL;
 	if (errstr != NULL)
 	    *errstr = strerror(errno);


### PR DESCRIPTION
This is because nbytes is passed as an integer to gzgets, a function in zlib.