### PR TITLE
Avoid compiler casting warnings by assigning to variables of the same type where possible

### DIFF
--- a/lib/eventlog/eventlog_free.c
+++ b/lib/eventlog/eventlog_free.c
@@ -41,7 +41,7 @@
 void
 eventlog_free(struct eventlog *evlog)
 {
-    int i;
+    size_t i;
     debug_decl(eventlog_free, SUDO_DEBUG_UTIL);
 
     if (evlog != NULL) {

--- a/lib/eventlog/parse_json.c
+++ b/lib/eventlog/parse_json.c
@@ -198,7 +198,7 @@ json_array_to_strvec(struct eventlog_json_object *array)
 static bool
 json_store_runargv(struct json_item *item, struct eventlog *evlog)
 {
-    int i;
+    size_t i;
     debug_decl(json_store_runargv, SUDO_DEBUG_UTIL);
 
     if (evlog->argv != NULL) {
@@ -214,7 +214,7 @@ json_store_runargv(struct json_item *item, struct eventlog *evlog)
 static bool
 json_store_runenv(struct json_item *item, struct eventlog *evlog)
 {
-    int i;
+    size_t i;
     debug_decl(json_store_runenv, SUDO_DEBUG_UTIL);
 
     if (evlog->envp != NULL) {
@@ -230,7 +230,7 @@ json_store_runenv(struct json_item *item, struct eventlog *evlog)
 static bool
 json_store_runenv_override(struct json_item *item, struct eventlog *evlog)
 {
-    int i;
+    size_t i;
     debug_decl(json_store_runenv_override, SUDO_DEBUG_UTIL);
 
     if (evlog->env_add != NULL) {

--- a/lib/iolog/hostcheck.c
+++ b/lib/iolog/hostcheck.c
@@ -130,8 +130,8 @@ static HostnameValidationResult
 validate_name(const char *hostname, ASN1_STRING *certname_asn1)
 {
     char *certname_s = (char *) ASN1_STRING_get0_data(certname_asn1);
-    int certname_len = ASN1_STRING_length(certname_asn1);
-    int hostname_len = strlen(hostname);
+    size_t certname_len = ASN1_STRING_length(certname_asn1);
+    size_t hostname_len = strlen(hostname);
     debug_decl(validate_name, SUDO_DEBUG_UTIL);
 
 	/* remove last '.' from hostname if exists */
@@ -140,18 +140,16 @@ validate_name(const char *hostname, ASN1_STRING *certname_asn1)
     }
 
 	sudo_debug_printf(SUDO_DEBUG_INFO|SUDO_DEBUG_LINENO,
-	    "comparing %.*s to %.*s in cert", hostname_len, hostname,
-	    certname_len, certname_s);
+	    "comparing %.*s to %.*s in cert", (int)hostname_len, hostname,
+	    (int)certname_len, certname_s);
 
 	/* skip the first label if wildcard */
 	if (certname_len > 2 && certname_s[0] == '*' && certname_s[1] == '.') {
-		if (hostname_len != 0) {
-			do {
-				--hostname_len;
-				if (*hostname++ == '.') {
-					break;
-                }
-			} while (hostname_len != 0);
+		while (hostname_len != 0) {
+			--hostname_len;
+			if (*hostname++ == '.') {
+				break;
+            }
 		}
 		certname_s += 2;
 		certname_len -= 2;
@@ -297,7 +295,7 @@ matches_subject_alternative_name(const char *hostname, const char *ipaddr, const
                     break;
                 }
 
-                int dns_name_length = ASN1_STRING_length(current_name->d.dNSName);
+                size_t dns_name_length = ASN1_STRING_length(current_name->d.dNSName);
                 char *nullterm_dns_name = malloc(dns_name_length + 1);
 
                 if (nullterm_dns_name == NULL) {

--- a/lib/iolog/regress/iolog_path/check_iolog_path.c
+++ b/lib/iolog/regress/iolog_path/check_iolog_path.c
@@ -133,7 +133,7 @@ do_check(char *dir_in, char *file_in, char *tdir_out, char *tfile_out)
     int error = 0;
     struct tm tm;
     time_t now;
-    int len;
+    size_t len;
 
     /*
      * Expand any strftime(3) escapes

--- a/lib/util/event.c
+++ b/lib/util/event.c
@@ -98,7 +98,7 @@ sudo_ev_activate_sigevents(struct sudo_event_base *base)
 {
     struct sudo_event *ev;
     sigset_t set, oset;
-    int i;
+    unsigned int i;
     debug_decl(sudo_ev_activate_sigevents, SUDO_DEBUG_EVENT);
 
     /*
@@ -168,7 +168,7 @@ signal_pipe_cb(int fd, int what, void *v)
 static int
 sudo_ev_base_init(struct sudo_event_base *base)
 {
-    int i;
+    unsigned int i;
     debug_decl(sudo_ev_base_init, SUDO_DEBUG_EVENT);
 
     TAILQ_INIT(&base->events);
@@ -218,7 +218,7 @@ void
 sudo_ev_base_free_v1(struct sudo_event_base *base)
 {
     struct sudo_event *ev, *next;
-    int i;
+    unsigned int i;
     debug_decl(sudo_ev_base_free, SUDO_DEBUG_EVENT);
 
     if (base == NULL)

--- a/lib/util/explicit_bzero.c
+++ b/lib/util/explicit_bzero.c
@@ -70,7 +70,7 @@ sudo_explicit_bzero(void *v, size_t n)
 
     /* Updating through a volatile pointer should not be optimized away. */
     while (n--)
-	*s++ = '\0';
+	*s++ = 0;
 }
 # endif /* HAVE_BZERO */
 

--- a/lib/util/fatal.c
+++ b/lib/util/fatal.c
@@ -72,7 +72,7 @@ do_cleanup(void)
     }
 }
 
-void
+sudo_noreturn void
 sudo_fatal_nodebug_v1(const char *fmt, ...)
 {
     va_list ap;
@@ -84,7 +84,7 @@ sudo_fatal_nodebug_v1(const char *fmt, ...)
     exit(EXIT_FAILURE);
 }
 
-void
+sudo_noreturn void
 sudo_fatalx_nodebug_v1(const char *fmt, ...)
 {
     va_list ap;
@@ -96,7 +96,7 @@ sudo_fatalx_nodebug_v1(const char *fmt, ...)
     exit(EXIT_FAILURE);
 }
 
-void
+sudo_noreturn void
 sudo_vfatal_nodebug_v1(const char *fmt, va_list ap)
 {
     warning(strerror(errno), fmt, ap);
@@ -104,7 +104,7 @@ sudo_vfatal_nodebug_v1(const char *fmt, va_list ap)
     exit(EXIT_FAILURE);
 }
 
-void
+sudo_noreturn void
 sudo_vfatalx_nodebug_v1(const char *fmt, va_list ap)
 {
     warning(NULL, fmt, ap);
@@ -143,7 +143,7 @@ sudo_vwarnx_nodebug_v1(const char *fmt, va_list ap)
     warning(NULL, fmt, ap);
 }
 
-void
+sudo_noreturn void
 sudo_gai_fatal_nodebug_v1(int errnum, const char *fmt, ...)
 {
     va_list ap;
@@ -155,7 +155,7 @@ sudo_gai_fatal_nodebug_v1(int errnum, const char *fmt, ...)
     exit(EXIT_FAILURE);
 }
 
-void
+sudo_noreturn void
 sudo_gai_vfatal_nodebug_v1(int errnum, const char *fmt, va_list ap)
 {
     warning(gai_strerror(errnum), fmt, ap);

--- a/lib/util/getaddrinfo.c
+++ b/lib/util/getaddrinfo.c
@@ -282,7 +282,7 @@ gai_lookup(const char *nodename, int flags, int socktype, unsigned short port,
     struct in_addr addr;
     struct hostent *host;
     const char *canonical;
-    int i;
+    size_t i;
 
     if (inet_pton(AF_INET, nodename, &addr)) {
         canonical = (flags & AI_CANONNAME) ? nodename : NULL;

--- a/lib/util/hexchar.c
+++ b/lib/util/hexchar.c
@@ -35,7 +35,7 @@ int
 sudo_hexchar_v1(const char *s)
 {
     unsigned char result[2];
-    int i;
+    unsigned int i;
     debug_decl(sudo_hexchar, SUDO_DEBUG_UTIL);
 
     for (i = 0; i < 2; i++) {

--- a/lib/util/inet_ntop.c
+++ b/lib/util/inet_ntop.c
@@ -76,7 +76,7 @@ inet_ntop4(const unsigned char *src, char *dst, socklen_t size)
 	int len;
 
 	len = snprintf(dst, size, fmt, src[0], src[1], src[2], src[3]);
-	if (len < 0 || (size_t)len >= size) {
+	if (len < 0 || (socklen_t)len >= size) {
 		errno = ENOSPC;
 		return (NULL);
 	}
@@ -113,7 +113,7 @@ inet_ntop6(const unsigned char *src, char *dst, socklen_t size)
 	 */
 	memset(words, 0, sizeof(words));
 	for (i = 0; i < NS_IN6ADDRSZ; i++)
-		words[i / 2] |= (src[i] << ((1 - (i % 2)) << 3));
+		words[i / 2] |= (src[i] << ((1 - (i & 1)) << 3));
 	best.base = -1;
 	best.len = 0;
 	cur.base = -1;

--- a/lib/util/json.c
+++ b/lib/util/json.c
@@ -72,7 +72,7 @@ json_expand_buf(struct json_container *jsonc)
 static bool
 json_new_line(struct json_container *jsonc)
 {
-    int indent = jsonc->indent_level;
+    unsigned int indent = jsonc->indent_level;
     debug_decl(json_new_line, SUDO_DEBUG_UTIL);
 
     /* No non-essential white space in minimal mode. */

--- a/lib/util/lbuf.c
+++ b/lib/util/lbuf.c
@@ -220,7 +220,7 @@ sudo_lbuf_append_quoted_v1(struct sudo_lbuf *lbuf, const char *set, const char *
     bool ret = false;
     const char *cp, *s;
     va_list ap;
-    int len;
+    unsigned int len;
     debug_decl(sudo_lbuf_append_quoted, SUDO_DEBUG_UTIL);
 
     if (sudo_lbuf_error(lbuf))
@@ -358,11 +358,11 @@ done:
 
 /* XXX - check output function return value */
 static void
-sudo_lbuf_println(struct sudo_lbuf *lbuf, char *line, int len)
+sudo_lbuf_println(struct sudo_lbuf *lbuf, char *line, size_t len)
 {
     char *cp, save;
-    int i, have, contlen = 0;
-    int indent = lbuf->indent;
+    size_t i, have, contlen = 0;
+    unsigned int indent = lbuf->indent;
     bool is_comment = false;
     debug_decl(sudo_lbuf_println, SUDO_DEBUG_UTIL);
 
@@ -382,14 +382,14 @@ sudo_lbuf_println(struct sudo_lbuf *lbuf, char *line, int len)
     have = lbuf->cols;
     while (cp != NULL && *cp != '\0') {
 	char *ep = NULL;
-	int need = len - (int)(cp - line);
+	size_t need = len - (cp - line);
 
 	if (need > have) {
 	    have -= contlen;		/* subtract for continuation char */
 	    if ((ep = memrchr(cp, ' ', have)) == NULL)
 		ep = memchr(cp + have, ' ', need - have);
 	    if (ep != NULL)
-		need = (int)(ep - cp);
+		need = (ep - cp);
 	}
 	if (cp != line) {
 	    if (is_comment) {
@@ -436,7 +436,7 @@ void
 sudo_lbuf_print_v1(struct sudo_lbuf *lbuf)
 {
     char *cp, *ep;
-    int len;
+    size_t len;
     debug_decl(sudo_lbuf_print, SUDO_DEBUG_UTIL);
 
     if (lbuf->buf == NULL || lbuf->len == 0)
@@ -460,7 +460,7 @@ sudo_lbuf_print_v1(struct sudo_lbuf *lbuf)
 	} else {
 	    len = lbuf->len - (cp - lbuf->buf);
 	    if ((ep = memchr(cp, '\n', len)) != NULL)
-		len = (int)(ep - cp);
+		len = (size_t)(ep - cp);
 	    if (len)
 		sudo_lbuf_println(lbuf, cp, len);
 	    cp = ep ? ep + 1 : NULL;

--- a/lib/util/mksiglist.c
+++ b/lib/util/mksiglist.c
@@ -34,7 +34,7 @@ sudo_dso_public int main(int argc, char *argv[]);
 int
 main(int argc, char *argv[])
 {
-    unsigned int i;
+    size_t i;
 
 #include "mksiglist.h"
 
@@ -43,10 +43,10 @@ main(int argc, char *argv[])
 	if (sudo_sys_siglist[i] != NULL) {
 	    printf("    \"%s\",\n", sudo_sys_siglist[i]);
 	} else {
-	    printf("    \"Signal %u\",\n", i);
+	    printf("    \"Signal %zu\",\n", i);
 	}
     }
     printf("};\n");
 
-    exit(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }

--- a/lib/util/mksigname.c
+++ b/lib/util/mksigname.c
@@ -34,7 +34,7 @@ sudo_dso_public int main(int argc, char *argv[]);
 int
 main(int argc, char *argv[])
 {
-    unsigned int i;
+    size_t i;
 
 #include "mksigname.h"
 
@@ -43,10 +43,10 @@ main(int argc, char *argv[])
 	if (sudo_sys_signame[i] != NULL) {
 	    printf("    \"%s\",\n", sudo_sys_signame[i]);
 	} else {
-	    printf("    \"Signal %u\",\n", i);
+	    printf("    \"Signal %zu\",\n", i);
 	}
     }
     printf("};\n");
 
-    exit(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }

--- a/lib/util/multiarch.c
+++ b/lib/util/multiarch.c
@@ -56,7 +56,7 @@ sudo_stat_multiarch_v1(const char *path, struct stat *sb)
     const char **lp, *lib, *slash;
     struct utsname unamebuf;
     char *newpath = NULL;
-    int len;
+    size_t len;
 
     if (uname(&unamebuf) == -1)
 	return NULL;
@@ -79,9 +79,8 @@ sudo_stat_multiarch_v1(const char *path, struct stat *sb)
 	}
 
 	/* Add machine-linux-gnu dir after /lib/ or /libexec/. */
-	len = asprintf(&newpath, "%.*s%s%s-linux-gnu%s",
-	    (int)(lib - path), path, newlib, unamebuf.machine, slash);
-	if (len == -1) {
+	if (asprintf(&newpath, "%.*s%s%s-linux-gnu%s",
+	    (int)(lib - path), path, newlib, unamebuf.machine, slash) == -1) {
 	    newpath = NULL;
 	    break;
 	}

--- a/lib/util/progname.c
+++ b/lib/util/progname.c
@@ -61,7 +61,7 @@ void
 initprogname2(const char *name, const char * const * allowed)
 {
     const char *progname;
-    int i;
+    size_t i;
 
     /* Fall back on "name" if getprogname() returns an empty string. */
     if ((progname = getprogname()) != NULL && *progname != '\0') {

--- a/lib/util/sig2str.c
+++ b/lib/util/sig2str.c
@@ -87,7 +87,7 @@ sudo_sig2str(int signo, char *signame)
 	    strlcpy(signame, cp, SIG2STR_MAX);
 	    /* Make sure we always return an upper case signame. */
 	    if (islower((unsigned char)signame[0])) {
-		int i;
+		size_t i;
 		for (i = 0; signame[i] != '\0'; i++)
 		    signame[i] = toupper((unsigned char)signame[i]);
 	    }

--- a/lib/util/snprintf.c
+++ b/lib/util/snprintf.c
@@ -107,7 +107,7 @@ union arg {
 };
 
 static int __find_arguments(const char *fmt0, va_list ap, union arg **argtable);
-static int __grow_type_table(unsigned char **typetable, int *tablesize);
+static int __grow_type_table(unsigned char **typetable, long *tablesize);
 static int xxxprintf(char **, size_t, int, const char *, va_list);
 
 #ifdef PRINTF_WIDE_CHAR
@@ -1089,9 +1089,9 @@ __find_arguments(const char *fmt0, va_list ap, union arg **argtable)
 	int flags;		/* flags as above */
 	unsigned char *typetable; /* table of types */
 	unsigned char stattypetable[STATIC_ARG_TBL_SIZE];
-	int tablesize;		/* current size of type table */
-	int tablemax;		/* largest used index in table */
-	int nextarg;		/* 1-based argument index */
+	long tablesize;		/* current size of type table */
+	long tablemax;		/* largest used index in table */
+	long nextarg;		/* 1-based argument index */
 	int ret = 0;		/* return value */
 
 	/*
@@ -1421,13 +1421,14 @@ finish:
  * Increase the size of the type table.
  */
 static int
-__grow_type_table(unsigned char **typetable, int *tablesize)
+__grow_type_table(unsigned char **typetable, long *tablesize)
 {
 	unsigned char *oldtable = *typetable;
-	int newsize = *tablesize * 2;
+	long newsize = *tablesize * 2;
+	long size = sysconf(_SC_PAGESIZE);
 
-	if (newsize < sysconf(_SC_PAGESIZE))
-		newsize = sysconf(_SC_PAGESIZE);
+	if (newsize < size)
+		newsize = size;
 
 	if (*tablesize == STATIC_ARG_TBL_SIZE) {
 		*typetable = sudo_mmap_alloc(newsize);

--- a/lib/util/sudo_conf.c
+++ b/lib/util/sudo_conf.c
@@ -377,8 +377,8 @@ parse_plugin(const char *entry, const char *conf_file, unsigned int lineno)
 oom:
     sudo_warnx(U_("%s: %s"), __func__, U_("unable to allocate memory"));
     if (options != NULL) {
-	while (nopts--)
-	    free(options[nopts]);
+	while (nopts)
+	    free(options[--nopts]);
 	free(options);
     }
     if (info != NULL) {
@@ -575,7 +575,7 @@ sudo_conf_init(int conf_types)
     struct sudo_conf_debug *debug_spec;
     struct sudo_debug_file *debug_file;
     struct plugin_info *plugin_info;
-    int i;
+    size_t i;
     debug_decl(sudo_conf_init, SUDO_DEBUG_UTIL);
 
     /* Free and reset paths. */
@@ -717,7 +717,7 @@ sudo_conf_read_v1(const char *path, int conf_types)
 
     while (sudo_parseln(&line, &linesize, &conf_lineno, fp, 0) != -1) {
 	struct sudo_conf_table *cur;
-	unsigned int i;
+	size_t i;
 	char *cp;
 
 	if (*(cp = line) == '\0')

--- a/lib/util/term.c
+++ b/lib/util/term.c
@@ -252,7 +252,7 @@ sudo_term_copy_v1(int src, int dst)
     struct termios tt_src, tt_dst;
     struct winsize wsize;
     speed_t speed;
-    int i;
+    unsigned int i;
     debug_decl(sudo_term_copy, SUDO_DEBUG_UTIL);
 
     if (tcgetattr(src, &tt_src) != 0 || tcgetattr(dst, &tt_dst) != 0)

--- a/lib/util/uuid.c
+++ b/lib/util/uuid.c
@@ -75,7 +75,7 @@ sudo_uuid_to_string_v1(unsigned char uuid[16], char *dst, size_t dstsiz)
 {
     const char hex[] = "0123456789abcdef";
     char *cp = dst;
-    int i;
+    unsigned int i;
 
     if (dstsiz < sizeof("123e4567-e89b-12d3-a456-426655440000"))
 	return NULL;

--- a/logsrvd/iolog_writer.c
+++ b/logsrvd/iolog_writer.c
@@ -106,8 +106,8 @@ strlist_copy(InfoMessage__StringList *strlist)
 
 bad:
     if (dst != NULL) {
-	while (i--)
-	    free(dst[i]);
+	while (i)
+	    free(dst[--i]);
 	free(dst);
     }
     debug_return_ptr(NULL);
@@ -603,14 +603,14 @@ void
 iolog_close_all(struct connection_closure *closure)
 {
     const char *errstr;
-    int i;
+    unsigned int i;
     debug_decl(iolog_close_all, SUDO_DEBUG_UTIL);
 
     for (i = 0; i < IOFD_MAX; i++) {
 	if (!closure->iolog_files[i].enabled)
 	    continue;
 	if (!iolog_close(&closure->iolog_files[i], &errstr)) {
-	    sudo_warnx(U_("error closing iofd %d: %s"), i, errstr);
+	    sudo_warnx(U_("error closing iofd %u: %s"), i, errstr);
 	}
     }
     if (closure->iolog_dir_fd != -1)
@@ -623,14 +623,15 @@ bool
 iolog_flush_all(struct connection_closure *closure)
 {
     const char *errstr;
-    int i, ret = true;
+    bool ret = true;
+    unsigned int i;
     debug_decl(iolog_flush_all, SUDO_DEBUG_UTIL);
 
     for (i = 0; i < IOFD_MAX; i++) {
 	if (!closure->iolog_files[i].enabled)
 	    continue;
 	if (!iolog_flush(&closure->iolog_files[i], &errstr)) {
-	    sudo_warnx(U_("error flushing iofd %d: %s"), i, errstr);
+	    sudo_warnx(U_("error flushing iofd %u: %s"), i, errstr);
 	    ret = false;
 	}
     }

--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -1899,7 +1899,7 @@ usage(bool fatal)
 	exit(EXIT_FAILURE);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     printf("%s - %s\n\n", getprogname(), _("sudo log server"));
@@ -1959,7 +1959,7 @@ main(int argc, char *argv[])
 
     /* Read sudo.conf and initialize the debug subsystem. */
     if (sudo_conf_read(NULL, SUDO_CONF_DEBUG) == -1)
-        exit(EXIT_FAILURE);
+        return EXIT_FAILURE;
     logsrvd_debug_instance = sudo_debug_register(getprogname(), NULL, NULL,
         sudo_conf_debug_files(getprogname()), -1);
 
@@ -1993,7 +1993,7 @@ main(int argc, char *argv[])
 
     /* Read sudo_logsrvd.conf */
     if (!logsrvd_conf_read(conf_file))
-        exit(EXIT_FAILURE);
+        return EXIT_FAILURE;
 
     if ((evbase = sudo_ev_base_alloc()) == NULL)
 	sudo_fatalx(U_("%s: %s"), __func__, U_("unable to allocate memory"));

--- a/logsrvd/sendlog.c
+++ b/logsrvd/sendlog.c
@@ -112,7 +112,7 @@ usage(bool fatal)
 	exit(EXIT_FAILURE);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     printf("%s - %s\n\n", getprogname(),
@@ -400,8 +400,8 @@ free_info_messages(InfoMessage **info_msgs, size_t n_info_msgs)
     debug_decl(free_info_messages, SUDO_DEBUG_UTIL);
 
     if (info_msgs != NULL) {
-	while (n_info_msgs-- > 0) {
-	    if (info_msgs[n_info_msgs]->value_case == INFO_MESSAGE__VALUE_STRLISTVAL) {
+	while (n_info_msgs) {
+	    if (info_msgs[--n_info_msgs]->value_case == INFO_MESSAGE__VALUE_STRLISTVAL) {
 		/* Only strlistval was dynamically allocated */
 		free(info_msgs[n_info_msgs]->u.strlistval->strings);
 		free(info_msgs[n_info_msgs]->u.strlistval);

--- a/plugins/audit_json/audit_json.c
+++ b/plugins/audit_json/audit_json.c
@@ -342,7 +342,7 @@ add_timestamp(struct json_container *jsonc, struct timespec *ts)
     time_t secs = ts->tv_sec;
     char timebuf[1024];
     struct tm gmt;
-    int len;
+    size_t len;
     debug_decl(add_timestamp, SUDO_DEBUG_PLUGIN);
 
     if (gmtime_r(&secs, &gmt) == NULL)

--- a/plugins/sudoers/cvtsudoers.c
+++ b/plugins/sudoers/cvtsudoers.c
@@ -1514,14 +1514,14 @@ print_usage(FILE *fp)
 	"[-P padding] [-s sections] [input_file]\n", getprogname());
 }
 
-static void
+sudo_noreturn static void
 usage(void)
 {
     print_usage(stderr);
     exit(EXIT_FAILURE);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     (void) printf(_("%s - convert between sudoers file formats\n\n"), getprogname());

--- a/plugins/sudoers/cvtsudoers_pwutil.c
+++ b/plugins/sudoers/cvtsudoers_pwutil.c
@@ -403,7 +403,7 @@ cvtsudoers_make_grlist_item(const struct passwd *pw, char * const *unused1)
     struct cache_item_grlist *grlitem;
     struct sudoers_string *s;
     struct group_list *grlist;
-    int groupname_len;
+    size_t groupname_len;
     debug_decl(cvtsudoers_make_grlist_item, SUDOERS_DEBUG_NSS);
 
     /*
@@ -421,7 +421,7 @@ cvtsudoers_make_grlist_item(const struct passwd *pw, char * const *unused1)
     }
 
 #ifdef _SC_LOGIN_NAME_MAX
-    groupname_len = MAX((int)sysconf(_SC_LOGIN_NAME_MAX), 32);
+    groupname_len = MAX(sysconf(_SC_LOGIN_NAME_MAX), 32);
 #else
     groupname_len = MAX(LOGIN_NAME_MAX, 32);
 #endif

--- a/plugins/sudoers/editor.c
+++ b/plugins/sudoers/editor.c
@@ -185,8 +185,9 @@ resolve_editor(const char *ed, size_t edlen, int nfiles, char * const *files,
     }
     if (nfiles != 0) {
 	nargv[nargc++] = (char *)"--";
-	while (nfiles--)
+	do
 	    nargv[nargc++] = *files++;
+	while (--nfiles > 0);
     }
     nargv[nargc] = NULL;
 
@@ -200,8 +201,8 @@ bad:
     free(editor);
     free(editor_path);
     if (nargv != NULL) {
-	while (nargc--) {
-	    sudoers_gc_remove(GC_PTR, nargv[nargc]);
+	while (nargc > 0) {
+	    sudoers_gc_remove(GC_PTR, nargv[--nargc]);
 	    free(nargv[nargc]);
 	}
 	sudoers_gc_remove(GC_PTR, nargv);

--- a/plugins/sudoers/getdate.c
+++ b/plugins/sudoers/getdate.c
@@ -2345,7 +2345,7 @@ difftm(struct tm *a, struct tm *b)
 {
   int ay = a->tm_year + (TM_YEAR_ORIGIN - 1);
   int by = b->tm_year + (TM_YEAR_ORIGIN - 1);
-  int days = (
+  long days = (
 	      /* difference in day of year */
 	      a->tm_yday - b->tm_yday
 	      /* + intervening leap days */
@@ -2451,7 +2451,6 @@ main(int argc, char *argv[])
 	(void)printf("\t> ");
 	(void)fflush(stdout);
     }
-    exit(0);
-    /* NOTREACHED */
+    return 0;
 }
 #endif	/* TEST */

--- a/plugins/sudoers/getdate.y
+++ b/plugins/sudoers/getdate.y
@@ -811,7 +811,7 @@ difftm(struct tm *a, struct tm *b)
 {
   int ay = a->tm_year + (TM_YEAR_ORIGIN - 1);
   int by = b->tm_year + (TM_YEAR_ORIGIN - 1);
-  int days = (
+  long days = (
 	      /* difference in day of year */
 	      a->tm_yday - b->tm_yday
 	      /* + intervening leap days */
@@ -917,7 +917,6 @@ main(int argc, char *argv[])
 	(void)printf("\t> ");
 	(void)fflush(stdout);
     }
-    exit(0);
-    /* NOTREACHED */
+    return 0;
 }
 #endif	/* TEST */

--- a/plugins/sudoers/iolog.c
+++ b/plugins/sudoers/iolog.c
@@ -851,7 +851,7 @@ done:
 static void
 sudoers_io_close_local(int exit_status, int error, const char **errstr)
 {
-    int i;
+    unsigned int i;
     debug_decl(sudoers_io_close_local, SUDOERS_DEBUG_PLUGIN);
 
     /* Close the files. */

--- a/plugins/sudoers/parse.c
+++ b/plugins/sudoers/parse.c
@@ -637,7 +637,7 @@ display_priv_long(struct sudoers_parse_tree *parse_tree, struct passwd *pw,
 	    struct member *m;
 
 	    if (new_long_entry(cs, prev_cs)) {
-		int olen;
+		unsigned int olen;
 
 		if (priv->ldap_role != NULL) {
 		    sudo_lbuf_append(lbuf, _("\nLDAP Role: %s\n"),
@@ -717,7 +717,7 @@ display_priv_long(struct sudoers_parse_tree *parse_tree, struct passwd *pw,
 		if (cs->notbefore != UNSPEC) {
 		    char buf[sizeof("CCYYMMDDHHMMSSZ")] = "";
 		    struct tm gmt;
-		    int len;
+		    size_t len;
 		    if (gmtime_r(&cs->notbefore, &gmt) != NULL) {
 			len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
 			if (len != 0 && buf[sizeof(buf) - 1] == '\0')
@@ -727,7 +727,7 @@ display_priv_long(struct sudoers_parse_tree *parse_tree, struct passwd *pw,
 		if (cs->notafter != UNSPEC) {
 		    char buf[sizeof("CCYYMMDDHHMMSSZ")] = "";
 		    struct tm gmt;
-		    int len;
+		    size_t len;
 		    if (gmtime_r(&cs->notafter, &gmt) != NULL) {
 			len = strftime(buf, sizeof(buf), "%Y%m%d%H%M%SZ", &gmt);
 			if (len != 0 && buf[sizeof(buf) - 1] == '\0')

--- a/plugins/sudoers/policy.c
+++ b/plugins/sudoers/policy.c
@@ -656,7 +656,7 @@ sudoers_policy_store_result(bool accepted, char *argv[], char *envp[],
     mode_t cmnd_umask, char *iolog_path, void *v)
 {
     struct sudoers_exec_args *exec_args = v;
-    int info_len = 0;
+    unsigned int info_len = 0;
     debug_decl(sudoers_policy_store_result, SUDOERS_DEBUG_PLUGIN);
 
     if (exec_args == NULL)
@@ -1051,8 +1051,8 @@ oom:
 bad:
     free(audit_msg);
     audit_msg = NULL;
-    while (info_len--)
-	free(command_info[info_len]);
+    while (info_len)
+	free(command_info[--info_len]);
     free(command_info);
     command_info = NULL;
     debug_return_bool(false);

--- a/plugins/sudoers/pwutil.c
+++ b/plugins/sudoers/pwutil.c
@@ -337,7 +337,7 @@ sudo_mkpwent(const char *user, uid_t uid, gid_t gid, const char *home,
     struct cache_item *item;
     struct passwd *pw;
     size_t len, name_len, home_len, shell_len;
-    int i;
+    unsigned int i;
     debug_decl(sudo_mkpwent, SUDOERS_DEBUG_NSS);
 
     if (pwcache_byuid == NULL)
@@ -648,7 +648,7 @@ sudo_mkgrent(const char *group, gid_t gid, ...)
     size_t nmem, nsize, total;
     char *cp, *mem;
     va_list ap;
-    int i;
+    unsigned int i;
     debug_decl(sudo_mkgrent, SUDOERS_DEBUG_NSS);
 
     if (grcache_bygid == NULL)

--- a/plugins/sudoers/regress/fuzz/fuzz_policy.c
+++ b/plugins/sudoers/regress/fuzz/fuzz_policy.c
@@ -92,7 +92,7 @@ struct dynamic_array {
 static void
 free_strvec(char **vec)
 {
-    int i;
+    size_t i;
 
     for (i = 0; vec[i] != NULL; i++)
 	free(vec[i]);

--- a/plugins/sudoers/regress/starttime/check_starttime.c
+++ b/plugins/sudoers/regress/starttime/check_starttime.c
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
     time_t timeoff = 0;
     pid_t pids[2];
     char *faketime;
-    int i;
+    unsigned int i;
 
     initprogname(argc > 0 ? argv[0] : "check_starttime");
 

--- a/plugins/sudoers/sssd.c
+++ b/plugins/sudoers/sssd.c
@@ -388,8 +388,8 @@ sss_to_sudoers(struct sudo_sss_handle *handle,
      * The conversion to a sudoers parse tree requires that entries be
      * in *ascending* order so we we iterate from last to first.
      */
-    for (i = sss_result->num_rules; i-- > 0; ) {
-	struct sss_sudo_rule *rule = sss_result->rules + i;
+    for (i = sss_result->num_rules; i; ) {
+	struct sss_sudo_rule *rule = sss_result->rules + --i;
 	struct privilege *priv;
 	int rc;
 

--- a/plugins/sudoers/sudoreplay.c
+++ b/plugins/sudoers/sudoreplay.c
@@ -1681,14 +1681,14 @@ print_usage(FILE *fp)
 	getprogname());
 }
 
-static void
+sudo_noreturn static void
 usage(void)
 {
     print_usage(stderr);
     exit(EXIT_FAILURE);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     (void) printf(_("%s - replay sudo session logs\n\n"), getprogname());

--- a/plugins/sudoers/timestr.c
+++ b/plugins/sudoers/timestr.c
@@ -36,7 +36,7 @@ get_timestr(time_t tstamp, int log_year)
 {
     static char buf[128];
     struct tm tm;
-    int len;
+    size_t len;
 
     if (localtime_r(&tstamp, &tm) != NULL) {
 	/* strftime() does not guarantee to NUL-terminate so we must check. */

--- a/plugins/sudoers/tsdump.c
+++ b/plugins/sudoers/tsdump.c
@@ -302,7 +302,7 @@ dump_entry(struct timestamp_entry *entry, off_t pos)
     debug_return;
 }
 
-static void
+sudo_noreturn static void
 usage(void)
 {
     fprintf(stderr, "usage: %s [-f timestamp_file] | [-u username]\n",

--- a/plugins/sudoers/visudo.c
+++ b/plugins/sudoers/visudo.c
@@ -339,7 +339,7 @@ main(int argc, char *argv[])
 
 done:
     sudo_debug_exit_int(__func__, __FILE__, __LINE__, sudo_debug_subsys, exitcode);
-    exit(exitcode);
+    return exitcode;
 }
 
 static bool
@@ -370,7 +370,7 @@ get_editor(int *editor_argc, char ***editor_argv)
     char *editor_path = NULL, **allowlist = NULL;
     const char *env_editor = NULL;
     static const char *files[] = { "+1", "sudoers" };
-    unsigned int allowlist_len = 0;
+    size_t allowlist_len = 0;
     debug_decl(get_editor, SUDOERS_DEBUG_UTIL);
 
     /* Build up editor allowlist from def_editor unless env_editor is set. */
@@ -412,8 +412,8 @@ get_editor(int *editor_argc, char ***editor_argv)
     }
 
     if (allowlist != NULL) {
-	while (allowlist_len--)
-	    free(allowlist[allowlist_len]);
+	while (allowlist_len)
+	    free(allowlist[--allowlist_len]);
 	free(allowlist);
     }
 
@@ -908,13 +908,11 @@ run_command(const char *path, char *const *argv)
     switch (pid = sudo_debug_fork()) {
 	case -1:
 	    sudo_fatal(U_("unable to execute %s"), path);
-	    break;	/* NOTREACHED */
 	case 0:
 	    closefrom(STDERR_FILENO + 1);
 	    execv(path, argv);
 	    sudo_warn(U_("unable to run %s"), path);
 	    _exit(127);
-	    break;	/* NOTREACHED */
     }
 
     for (;;) {
@@ -1319,14 +1317,14 @@ quit(int signo)
 
 #define VISUDO_USAGE	"usage: %s [-chqsV] [[-f] sudoers ]\n"
 
-static void
+sudo_noreturn static void
 usage(void)
 {
     (void) fprintf(stderr, VISUDO_USAGE, getprogname());
     exit(EXIT_FAILURE);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     (void) printf(_("%s - safely edit the sudoers file\n\n"), getprogname());

--- a/src/conversation.c
+++ b/src/conversation.c
@@ -140,7 +140,7 @@ err:
 		continue;
 	    freezero(repl->reply, strlen(repl->reply));
 	    repl->reply = NULL;
-	} while (n--);
+	} while (n-- > 0);
     }
 
     sudo_debug_set_active_instance(conv_debug_instance);
@@ -179,12 +179,17 @@ sudo_conversation_printf(int msg_type, const char *fmt, ...)
 	FALLTHROUGH;
     case SUDO_CONV_INFO_MSG:
 	/* Convert nl -> cr nl in case tty is in raw mode. */
-	len = strlen(fmt);
 	if (sudo_term_is_raw(fileno(ttyfp ? ttyfp : fp))) {
-	    if (len < ssizeof(fmt2) && len > 0 && fmt[len - 1] == '\n') {
-		if (len == 1 || fmt[len - 2] != '\r') {
-		    memcpy(fmt2, fmt, len - 1);
-		    fmt2[len - 1] = '\0';
+		size_t fmtlen = strlen(fmt);
+	    if (fmtlen < sizeof(fmt2) && fmtlen && fmt[fmtlen - 1] == '\n') {
+		if (fmtlen == 1) {
+			fmt2[0] = '\0';
+			fmt = fmt2;
+		    crnl = "\r\n";
+		}
+		else if (fmt[fmtlen - 2] != '\r') {
+		    memcpy(fmt2, fmt, fmtlen - 1);
+		    fmt2[fmtlen - 1] = '\0';
 		    fmt = fmt2;
 		    crnl = "\r\n";
 		}

--- a/src/exec_monitor.c
+++ b/src/exec_monitor.c
@@ -128,10 +128,10 @@ deliver_signal(struct monitor_closure *mc, int signo, bool from_parent)
  * Send status to parent over socketpair.
  * Return value is the same as send(2).
  */
-static int
+static ssize_t
 send_status(int fd, struct command_status *cstat)
 {
-    int n = -1;
+    ssize_t n = -1;
     debug_decl(send_status, SUDO_DEBUG_EXEC);
 
     if (cstat->type != CMD_INVALID) {
@@ -139,7 +139,7 @@ send_status(int fd, struct command_status *cstat)
 	    "sending status message to parent: [%d, %d]",
 	    cstat->type, cstat->val);
 	n = send(fd, cstat, sizeof(*cstat), 0);
-	if (n != sizeof(*cstat)) {
+	if (n != ssizeof(*cstat)) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
 		"%s: unable to send status to parent", __func__);
 	}

--- a/src/limits.c
+++ b/src/limits.c
@@ -672,7 +672,7 @@ set_policy_rlimits(void)
 }
 
 int
-serialize_rlimits(char **info, size_t info_max)
+serialize_rlimits(char **info, unsigned int info_max)
 {
     char *str;
     unsigned int idx, nstored = 0;
@@ -708,7 +708,7 @@ serialize_rlimits(char **info, size_t info_max)
     }
     debug_return_int(nstored);
 oom:
-    while (nstored--)
-	free(info[nstored]);
+    while (nstored)
+	free(info[--nstored]);
     debug_return_int(-1);
 }

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -704,7 +704,8 @@ display_usage(FILE *fp)
 {
     const char * const **uvecs = sudo_usage;
     const char * const *uvec;
-    int i, indent;
+    size_t i;
+    int indent;
 
     /*
      * Use usage vectors appropriate to the progname.
@@ -725,7 +726,7 @@ display_usage(FILE *fp)
 /*
  * Display usage message and exit.
  */
-void
+sudo_noreturn void
 usage(void)
 {
     display_usage(stderr);
@@ -764,7 +765,7 @@ help_out(const char *buf)
     return fputs(buf, stdout);
 }
 
-static void
+sudo_noreturn static void
 help(void)
 {
     struct sudo_lbuf lbuf;

--- a/src/sesh.c
+++ b/src/sesh.c
@@ -148,7 +148,6 @@ main(int argc, char *argv[], char *envp[])
 	    break;
 	default:
 	    usage();
-	    break;
 	}
     }
     argc -= optind;

--- a/src/sudo.h
+++ b/src/sudo.h
@@ -343,7 +343,7 @@ void restore_nproc(void);
 void set_policy_rlimits(void);
 void unlimit_nproc(void);
 void unlimit_sudo(void);
-int serialize_rlimits(char **info, size_t info_max);
+int serialize_rlimits(char **info, unsigned int info_max);
 bool parse_policy_rlimit(const char *str);
 
 /* exec_ptrace.c */


### PR DESCRIPTION
This saves instructions that are related to casting as well as compiler warnings.