### PR TITLE
Do variable length arrays the C99 way

### DIFF
--- a/include/sudo_event.h
+++ b/include/sudo_event.h
@@ -64,7 +64,7 @@ typedef void (*sudo_ev_callback_t)(int fd, int what, void *closure);
 struct sudo_ev_siginfo_container {
     void *closure;
     siginfo_t *siginfo;
-    char si_buf[1];
+    char si_buf[];
 };
 
 /* Member of struct sudo_event_base. */

--- a/lib/util/event.c
+++ b/lib/util/event.c
@@ -291,7 +291,7 @@ sudo_ev_set_v1(struct sudo_event *ev, int fd, short events,
     /* For SUDO_EV_SIGINFO we use a container to store closure + siginfo_t */
     if (ISSET(events, SUDO_EV_SIGINFO)) {
 	struct sudo_ev_siginfo_container *container =
-	    malloc(sizeof(*container) + sizeof(siginfo_t) - 1);
+	    malloc(sizeof(*container) + sizeof(siginfo_t));
 	if (container == NULL) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_LINENO,
 		"%s: unable to allocate siginfo container", __func__);

--- a/lib/util/rcstr.c
+++ b/lib/util/rcstr.c
@@ -34,7 +34,7 @@
 /* Trivial reference-counted strings. */
 struct rcstr {
     int refcnt;
-    char str[1];	/* actually bigger */
+    char str[];
 };
 
 /*
@@ -62,8 +62,7 @@ sudo_rcstr_alloc(size_t len)
     struct rcstr *rcs;
     debug_decl(sudo_rcstr_dup, SUDO_DEBUG_UTIL);
 
-    /* Note: sizeof(struct rcstr) includes space for the NUL */
-    rcs = malloc(sizeof(struct rcstr) + len);
+    rcs = malloc(sizeof(struct rcstr) + len + 1);
     if (rcs == NULL)
 	return NULL;
 

--- a/plugins/sudoers/canon_path.c
+++ b/plugins/sudoers/canon_path.c
@@ -41,12 +41,12 @@ static struct rbtree *canon_cache;
  * resolved path.  The resolved path is directly embedded into the
  * struct so that we can find the start of the struct cache_item
  * given the value of resolved.  Storage for pathname is embedded
- * at the end, after resolved.
+ * at the end with resolved.
  */
 struct cache_item {
     unsigned int refcnt;
     char *pathname;
-    char resolved[1];	/* actually bigger */
+    char resolved[];
 };
 
 /*
@@ -150,7 +150,8 @@ canon_path(const char *inpath)
 	resolved = realpath(inpath, resbuf);
 
     inlen = strlen(inpath);
-    item_size = sizeof(*item) + inlen + 1;
+    /* one for NULL terminator of resolved, one for NULL terminator of pathname */
+    item_size = sizeof(*item) + inlen + 2;
     if (resolved != NULL) {
 	reslen = strlen(resolved);
 	item_size += reslen;

--- a/plugins/sudoers/ldap_conf.c
+++ b/plugins/sudoers/ldap_conf.c
@@ -452,7 +452,7 @@ sudo_ldap_parse_keyword(const char *keyword, const char *value,
 
 		    if (len > 0) {
 			head = (struct ldap_config_str_list *)cur->valp;
-			if ((str = malloc(sizeof(*str) + len)) == NULL) {
+			if ((str = malloc(sizeof(*str) + len + 1)) == NULL) {
 			    sudo_warnx(U_("%s: %s"), __func__, U_("unable to allocate memory"));
 			    debug_return_bool(false);
 			}

--- a/plugins/sudoers/sudo_ldap_conf.h
+++ b/plugins/sudoers/sudo_ldap_conf.h
@@ -44,7 +44,7 @@ struct ldap_config_table {
 
 struct ldap_config_str {
     STAILQ_ENTRY(ldap_config_str) entries;
-    char val[1];
+    char val[];
 };
 STAILQ_HEAD(ldap_config_str_list, ldap_config_str);
 


### PR DESCRIPTION
Variable length arrays are supported by C99, but having it denoted as "1" confused the compiler and is not defined.

Note that because we don't get the inferred NULL terminator, we have to increase the malloc size by one.