### PR TITLE
Remove ENV environment variable from badenv table

### DIFF
--- a/plugins/sudoers/env.c
+++ b/plugins/sudoers/env.c
@@ -169,7 +169,6 @@ static const char *initial_badenv_table[] = {
     "TERMINFO_DIRS",		/* terminfo, path(s) to terminfo files */
     "TERMPATH",			/* termcap, path(s) to termcap files */
     "TERMCAP",			/* XXX - only if it starts with '/' */
-    "ENV",			/* ksh, file to source before script runs */
     "BASH_ENV",			/* bash, file to source before script runs */
     "PS4",			/* bash, prefix for lines in xtrace mode */
     "GLOBIGNORE",		/* bash, globbing patterns to ignore */
@@ -885,7 +884,7 @@ rebuild_env(void)
     /* Reset HOME based on target user if configured to. */
     if (ISSET(sudo_mode, MODE_RUN)) {
 	if (def_always_set_home ||
-	    ISSET(sudo_mode, MODE_RESET_HOME | MODE_LOGIN_SHELL) || 
+	    ISSET(sudo_mode, MODE_RESET_HOME | MODE_LOGIN_SHELL) ||
 	    (ISSET(sudo_mode, MODE_SHELL) && def_set_home))
 	    reset_home = true;
     }


### PR DESCRIPTION
The `ENV` variable was banned and not usable with `sudo -E`.
It doesn't serve any appropriate safety measure anymore, and by default (without `--preserve-env=ENV`) it can leads to issues passing the ENV variable, which is used in many CI/CD procedures to separate development/staging/production environments.