### PR TITLE
Reference the SETENV-related settings in the command enviornment section.

### DIFF
--- a/docs/sudoers.man.in
+++ b/docs/sudoers.man.in
@@ -475,14 +475,33 @@ varies based on the operating system
 \fBsudo\fR
 is running on.
 .PP
-Other
+Other settings may influence the command environment:
+.TP 3n
+\fB\(bu\fR
 \fBsudoers\fR
-options may influence the command environment, such as
+options, such as
 \fIalways_set_home\fR,
 \fIsecure_path\fR,
 \fIset_logname\fR,
+\fIset_home\fR,
+\fIsetenv\fR.
+.TP 3n
+\fB\(bu\fR
+Command tags, such as
+\fISETENV\fR
 and
-\fIset_home\fR.
+\fINOSETENV\fR.
+Note that
+\fISETENV\fR
+is implied if the command matched is
+\fBALL\fR.
+.TP 3n
+\fB\(bu\fR
+\fBsudo\fR
+options, such as
+\fI-E\fR
+and
+\fI-i\fR.
 .PP
 On systems that support PAM where the
 \fBpam_env\fR


### PR DESCRIPTION
The ALL command matcher is used by default for admin users (often the only login users) on many systems. They should be mentioned in the [Command environment](https://www.sudo.ws/docs/man/sudoers.man/#Command_environment) section.