### PR TITLE
Modify the is_script function for match_command.c

### DIFF
--- a/plugins/sudoers/match_command.c
+++ b/plugins/sudoers/match_command.c
@@ -163,7 +163,7 @@ is_script(int fd)
 	if (magic[0] == '#' && magic[1] == '!')
 	    ret = true;
     }
-    debug_return_int(ret);
+    debug_return_bool(ret);
 }
 
 /*


### PR DESCRIPTION
Because the return value of the is_script function is bool type, so change 'debug_return_int(ret)' to 'debug_return_bool(ret)'