### PR TITLE
Set command_info to NULL once it is freed

### DIFF
--- a/plugins/sudoers/policy.c
+++ b/plugins/sudoers/policy.c
@@ -1054,6 +1054,7 @@ bad:
     while (info_len--)
 	free(command_info[info_len]);
     free(command_info);
+    command_info = NULL;
     debug_return_bool(false);
 }
 


### PR DESCRIPTION
The lack of setting to NULL is a holdover from when command_info was a local variable and not a global one. However, we given how other global variables are set to NULL, it is best that we do the same here to avoid potential issues should sudoers_policy_store_result be called again after the first time failed, otherwise we could get a double-free.