### PR TITLE
We should be returning 0, not 1, when logservd finishes without errors

### DIFF
--- a/logsrvd/logsrvd.c
+++ b/logsrvd/logsrvd.c
@@ -2017,5 +2017,5 @@ main(int argc, char *argv[])
 	unlink(logsrvd_conf_pid_file());
     logsrvd_conf_cleanup();
 
-    debug_return_int(1);
+    debug_return_int(0);
 }


### PR DESCRIPTION
1 is for failure, 0 is for no failure, and this does not look like a failure.