### PR TITLE
Fixed even more signedness and conversion issues

### DIFF
--- a/lib/iolog/iolog_loginfo.c
+++ b/lib/iolog/iolog_loginfo.c
@@ -118,8 +118,8 @@ iolog_write_info_file_legacy(int dfd, struct eventlog *evlog)
     }
     if (fchown(fd, iolog_get_uid(), iolog_get_gid()) != 0) {
 	sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-	    "%s: unable to fchown %d:%d %s/log", __func__,
-	    (int)iolog_get_uid(), (int)iolog_get_gid(), evlog->iolog_path);
+	    "%s: unable to fchown %u:%u %s/log", __func__,
+	    (unsigned int)iolog_get_uid(), (unsigned int)iolog_get_gid(), evlog->iolog_path);
     }
 
     fprintf(fp, "%lld:%s:%s:%s:%s:%d:%d\n%s\n",
@@ -192,8 +192,8 @@ iolog_write_info_file_json(int dfd, struct eventlog *evlog)
     }
     if (fchown(fd, iolog_get_uid(), iolog_get_gid()) != 0) {
 	sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-	    "%s: unable to fchown %d:%d %s/log.json", __func__,
-	    (int)iolog_get_uid(), (int)iolog_get_gid(), evlog->iolog_path);
+	    "%s: unable to fchown %u:%u %s/log.json", __func__,
+	    (unsigned int)iolog_get_uid(), (unsigned int)iolog_get_gid(), evlog->iolog_path);
     }
     fd = -1;
 

--- a/lib/iolog/iolog_mkdirs.c
+++ b/lib/iolog/iolog_mkdirs.c
@@ -74,8 +74,8 @@ iolog_mkdirs(const char *path)
 	    if (sb.st_uid != iolog_uid || sb.st_gid != iolog_gid) {
 		if (fchown(dfd, iolog_uid, iolog_gid) != 0) {
 		    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-			"%s: unable to chown %d:%d %s", __func__,
-			(int)iolog_uid, (int)iolog_gid, path);
+			"%s: unable to chown %u:%u %s", __func__,
+			(unsigned int)iolog_uid, (unsigned int)iolog_gid, path);
 		}
 	    }
 	    if ((sb.st_mode & ALLPERMS) != iolog_dirmode) {
@@ -87,7 +87,7 @@ iolog_mkdirs(const char *path)
 	    }
 	} else {
 	    sudo_warnx(U_("%s exists but is not a directory (0%o)"),
-		path, (unsigned int) sb.st_mode);
+		path, (int) sb.st_mode);
 	    ok = false;
 	}
 	goto done;
@@ -116,16 +116,17 @@ iolog_mkdirs(const char *path)
 	    if (errno == EACCES && !uid_changed) {
 		/* Try again as the I/O log owner (for NFS). */
 		uid_changed = iolog_swapids(false);
-		if (uid_changed)
+		if (uid_changed) {
 		    ok = mkdirat(dfd, base, iolog_dirmode) == 0 || errno == EEXIST;
+			if (!ok)
+				sudo_warn(U_("unable to mkdir %s"), path);
+		}
 	    }
-	    if (!ok)
-		sudo_warn(U_("unable to mkdir %s"), path);
 	} else {
 	    if (fchownat(dfd, base, iolog_uid, iolog_gid, AT_SYMLINK_NOFOLLOW) != 0) {
 		sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		    "%s: unable to chown %d:%d %s", __func__,
-		    (int)iolog_uid, (int)iolog_gid, path);
+		    "%s: unable to chown %u:%u %s", __func__,
+		    (unsigned int)iolog_uid, (unsigned int)iolog_gid, path);
 	    }
 	}
     }

--- a/lib/iolog/iolog_nextid.c
+++ b/lib/iolog/iolog_nextid.c
@@ -100,8 +100,8 @@ iolog_nextid(const char *iolog_dir, char sessid[7])
     }
     if (fchown(fd, iolog_uid, iolog_gid) != 0) {
 	sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-	    "%s: unable to fchown %d:%d %s", __func__,
-	    (int)iolog_uid, (int)iolog_gid, pathbuf);
+	    "%s: unable to fchown %u:%u %s", __func__,
+	    (unsigned int)iolog_uid, (unsigned int)iolog_gid, pathbuf);
     }
 
     /* Read current seq number (base 36). */

--- a/lib/iolog/iolog_open.c
+++ b/lib/iolog/iolog_open.c
@@ -80,8 +80,8 @@ iolog_open(struct iolog_file *iol, int dfd, int iofd, const char *mode)
 	    if (*mode == 'w') {
 		if (fchown(fd, iolog_uid, iolog_gid) != 0) {
 		    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-			"%s: unable to fchown %d:%d %s", __func__,
-			(int)iolog_uid, (int)iolog_gid, file);
+			"%s: unable to fchown %u:%u %s", __func__,
+			(unsigned int)iolog_uid, (unsigned int)iolog_gid, file);
 		}
 		iol->compressed = iolog_get_compress();
 	    } else {

--- a/lib/iolog/iolog_swapids.c
+++ b/lib/iolog/iolog_swapids.c
@@ -61,30 +61,30 @@ iolog_swapids(bool restore)
     if (restore) {
 	if (seteuid(user_euid) == -1) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		"%s: unable to restore effective uid to %d", __func__,
-		(int)user_euid);
-	    sudo_warn("seteuid() %d -> %d", (int)iolog_uid, (int)user_euid);
+		"%s: unable to restore effective uid to %u", __func__,
+		(unsigned int)user_euid);
+	    sudo_warn("seteuid() %u -> %u", (unsigned int)iolog_uid, (unsigned int)user_euid);
 	    debug_return_bool(false);
 	}
 	if (setegid(user_egid) == -1) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		"%s: unable to restore effective gid to %d", __func__,
-		(int)user_egid);
-	    sudo_warn("setegid() %d -> %d", (int)iolog_gid, (int)user_egid);
+		"%s: unable to restore effective gid to %u", __func__,
+		(unsigned int)user_egid);
+	    sudo_warn("setegid() %u -> %u", (unsigned int)iolog_gid, (unsigned int)user_egid);
 	    debug_return_bool(false);
 	}
     } else {
 	/* Fail silently if the user has insufficient privileges. */
 	if (setegid(iolog_gid) == -1) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		"%s: unable to set effective gid to %d", __func__,
-		(int)iolog_gid);
+		"%s: unable to set effective gid to %u", __func__,
+		(unsigned int)iolog_gid);
 	    debug_return_bool(false);
 	}
 	if (seteuid(iolog_uid) == -1) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		"%s: unable to set effective uid to %d", __func__,
-		(int)iolog_uid);
+		"%s: unable to set effective uid to %u", __func__,
+		(unsigned int)iolog_uid);
 	    debug_return_bool(false);
 	}
     }

--- a/lib/util/mkdir_parents.c
+++ b/lib/util/mkdir_parents.c
@@ -112,8 +112,8 @@ sudo_open_parent_dir_v1(const char *path, uid_t uid, gid_t gid, mode_t mode,
 	int dfd;
 
 	sudo_debug_printf(SUDO_DEBUG_DEBUG|SUDO_DEBUG_LINENO,
-	    "mkdir %.*s, mode 0%o, uid %d, gid %d", (int)(ep - path), path,
-	    (unsigned int)mode, (int)uid, (int)gid);
+	    "mkdir %.*s, mode 0%o, uid %u, gid %u", (int)(ep - path), path,
+	    (int)mode, (unsigned int)uid, (unsigned int)gid);
 	if (len >= sizeof(name)) {
 	    errno = ENAMETOOLONG;
 	    if (!quiet)
@@ -149,8 +149,8 @@ reopen:
 		if (uid != (uid_t)-1 && gid != (gid_t)-1) {
 		    if (fchown(dfd, uid, gid) != 0) {
 			sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-			    "%s: unable to chown %d:%d %.*s", __func__,
-			    (int)uid, (int)gid, (int)(ep - path), path);
+			    "%s: unable to chown %u:%u %.*s", __func__,
+			    (unsigned int)uid, (unsigned int)gid, (int)(ep - path), path);
 		    }
 		}
 	    } else {

--- a/lib/util/regress/parse_gids/parse_gids_test.c
+++ b/lib/util/regress/parse_gids/parse_gids_test.c
@@ -60,7 +60,7 @@ dump_gids(const char *prefix, int ngids, const GETGROUPS_T *gidlist)
 
     fprintf(stderr, "%s: %s: ", getprogname(), prefix);
     for (i = 0; i < ngids; i++) {
-	fprintf(stderr, "%s%d", i ? ", " : "", (int)gidlist[i]);
+	fprintf(stderr, "%s%u", i ? ", " : "", (unsigned int)gidlist[i]);
     }
     fputc('\n', stderr);
 }

--- a/lib/util/sudo_debug.c
+++ b/lib/util/sudo_debug.c
@@ -536,7 +536,7 @@ sudo_debug_exit_id_t_v1(const char *func, const char *file, int line,
 	"<- %s @ %s:%d := %lld", func, file, line, (long long)ret);
 #else
     sudo_debug_printf2(NULL, NULL, 0, subsys | SUDO_DEBUG_TRACE,
-	"<- %s @ %s:%d := %d", func, file, line, (int)ret);
+	"<- %s @ %s:%d := %u", func, file, line, (unsigned int)ret);
 #endif
 }
 
@@ -565,7 +565,7 @@ sudo_debug_exit_time_t_v1(const char *func, const char *file, int line,
 	"<- %s @ %s:%d := %lld", func, file, line, (long long)ret);
 #else
     sudo_debug_printf2(NULL, NULL, 0, subsys | SUDO_DEBUG_TRACE,
-	"<- %s @ %s:%d := %d", func, file, line, (int)ret);
+	"<- %s @ %s:%d := %ld", func, file, line, (long)ret);
 #endif
 }
 

--- a/plugins/sudoers/gram.c
+++ b/plugins/sudoers/gram.c
@@ -159,10 +159,10 @@ struct sudoers_parse_tree parsed_policy = {
  * Local prototypes
  */
 static void init_options(struct command_options *opts);
-static bool add_defaults(int, struct member *, struct defaults *);
+static bool add_defaults(short, struct member *, struct defaults *);
 static bool add_userspec(struct member *, struct privilege *);
 static struct defaults *new_default(char *, char *, short);
-static struct member *new_member(char *, int);
+static struct member *new_member(char *, short);
 static struct sudo_command *new_command(char *, char *);
 static struct command_digest *new_digest(unsigned int, char *);
 static void alias_error(const char *name, int errnum);
@@ -3406,7 +3406,7 @@ yyreturnlab:
 void
 sudoerserrorf(const char *fmt, ...)
 {
-    const int column = sudolinebuf.toke_start + 1;
+    const int column = (int)(sudolinebuf.toke_start + 1);
     va_list ap;
     debug_decl(sudoerserrorf, SUDOERS_DEBUG_PARSER);
 
@@ -3438,8 +3438,8 @@ sudoerserrorf(const char *fmt, ...)
 		    tofree = NULL;
 		}
 	    }
-	    sudo_printf(SUDO_CONV_ERROR_MSG, _("%s:%d:%d: %s\n"), sudoers,
-		this_lineno, (int)sudolinebuf.toke_start + 1, s);
+	    sudo_printf(SUDO_CONV_ERROR_MSG, _("%s:%d:%zu: %s\n"), sudoers,
+		this_lineno, sudolinebuf.toke_start + 1, s);
 	    free(tofree);
 	    va_end(ap);
 	    sudoers_setlocale(oldlocale, NULL);
@@ -3515,7 +3515,7 @@ new_default(char *var, char *val, short op)
     d->op = op;
     /* d->binding = NULL; */
     d->line = this_lineno;
-    d->column = sudolinebuf.toke_start + 1;
+    d->column = (int)(sudolinebuf.toke_start + 1);
     d->file = sudo_rcstr_addref(sudoers);
     HLTQ_INIT(d, entries);
 
@@ -3523,7 +3523,7 @@ new_default(char *var, char *val, short op)
 }
 
 static struct member *
-new_member(char *name, int type)
+new_member(char *name, short type)
 {
     struct member *m;
     debug_decl(new_member, SUDOERS_DEBUG_PARSER);
@@ -3608,7 +3608,7 @@ free_defaults_binding(struct defaults_binding *binding)
  * or runas users the entries apply to (determined by the type).
  */
 static bool
-add_defaults(int type, struct member *bmem, struct defaults *defs)
+add_defaults(short type, struct member *bmem, struct defaults *defs)
 {
     struct defaults *d, *next;
     struct defaults_binding *binding;
@@ -3667,7 +3667,7 @@ add_userspec(struct member *members, struct privilege *privs)
     }
     /* We already parsed the newline so sudolineno is off by one. */
     u->line = sudolineno - 1;
-    u->column = sudolinebuf.toke_start + 1;
+    u->column = (int)(sudolinebuf.toke_start + 1);
     u->file = sudo_rcstr_addref(sudoers);
     parser_leak_remove(LEAK_MEMBER, members);
     HLTQ_TO_TAILQ(&u->users, members, entries);

--- a/plugins/sudoers/gram.y
+++ b/plugins/sudoers/gram.y
@@ -76,10 +76,10 @@ struct sudoers_parse_tree parsed_policy = {
  * Local prototypes
  */
 static void init_options(struct command_options *opts);
-static bool add_defaults(int, struct member *, struct defaults *);
+static bool add_defaults(short, struct member *, struct defaults *);
 static bool add_userspec(struct member *, struct privilege *);
 static struct defaults *new_default(char *, char *, short);
-static struct member *new_member(char *, int);
+static struct member *new_member(char *, short);
 static struct sudo_command *new_command(char *, char *);
 static struct command_digest *new_digest(unsigned int, char *);
 static void alias_error(const char *name, int errnum);
@@ -1223,7 +1223,7 @@ group		:	ALIAS {
 void
 sudoerserrorf(const char *fmt, ...)
 {
-    const int column = sudolinebuf.toke_start + 1;
+    const int column = (int)(sudolinebuf.toke_start + 1);
     va_list ap;
     debug_decl(sudoerserrorf, SUDOERS_DEBUG_PARSER);
 
@@ -1255,8 +1255,8 @@ sudoerserrorf(const char *fmt, ...)
 		    tofree = NULL;
 		}
 	    }
-	    sudo_printf(SUDO_CONV_ERROR_MSG, _("%s:%d:%d: %s\n"), sudoers,
-		this_lineno, (int)sudolinebuf.toke_start + 1, s);
+	    sudo_printf(SUDO_CONV_ERROR_MSG, _("%s:%d:%zu: %s\n"), sudoers,
+		this_lineno, sudolinebuf.toke_start + 1, s);
 	    free(tofree);
 	    va_end(ap);
 	    sudoers_setlocale(oldlocale, NULL);
@@ -1332,7 +1332,7 @@ new_default(char *var, char *val, short op)
     d->op = op;
     /* d->binding = NULL; */
     d->line = this_lineno;
-    d->column = sudolinebuf.toke_start + 1;
+    d->column = (int)(sudolinebuf.toke_start + 1);
     d->file = sudo_rcstr_addref(sudoers);
     HLTQ_INIT(d, entries);
 
@@ -1340,7 +1340,7 @@ new_default(char *var, char *val, short op)
 }
 
 static struct member *
-new_member(char *name, int type)
+new_member(char *name, short type)
 {
     struct member *m;
     debug_decl(new_member, SUDOERS_DEBUG_PARSER);
@@ -1425,7 +1425,7 @@ free_defaults_binding(struct defaults_binding *binding)
  * or runas users the entries apply to (determined by the type).
  */
 static bool
-add_defaults(int type, struct member *bmem, struct defaults *defs)
+add_defaults(short type, struct member *bmem, struct defaults *defs)
 {
     struct defaults *d, *next;
     struct defaults_binding *binding;
@@ -1484,7 +1484,7 @@ add_userspec(struct member *members, struct privilege *privs)
     }
     /* We already parsed the newline so sudolineno is off by one. */
     u->line = sudolineno - 1;
-    u->column = sudolinebuf.toke_start + 1;
+    u->column = (int)(sudolinebuf.toke_start + 1);
     u->file = sudo_rcstr_addref(sudoers);
     parser_leak_remove(LEAK_MEMBER, members);
     HLTQ_TO_TAILQ(&u->users, members, entries);

--- a/plugins/sudoers/set_perms.c
+++ b/plugins/sudoers/set_perms.c
@@ -156,9 +156,9 @@ set_perms(int perm)
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_INITIAL: "
-	    "ruid: %d, euid: %d, suid: %d, rgid: %d, egid: %d, sgid: %d",
-	    __func__, (int)state->ruid, (int)state->euid, (int)state->suid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "ruid: %u, euid: %u, suid: %u, rgid: %u, egid: %u, sgid: %u",
+	    __func__, (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	break;
 
     case PERM_ROOT:
@@ -166,22 +166,22 @@ set_perms(int perm)
 	state->euid = ROOT_UID;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_ROOT: setresuid(%d, %d, %d)",
-		(int)ID(ruid), (int)ID(euid), (int)ID(suid));
+		"PERM_ROOT: setresuid(%u, %u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid), (unsigned int)ID(suid));
 	    goto bad;
 	}
 	state->rgid = ostate->rgid;
 	state->egid = ROOT_GID;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setresgid(ID(rgid), ID(egid), ID(sgid))) {
 	    errstr = N_("unable to change to root gid");
 	    goto bad;
@@ -195,13 +195,13 @@ set_perms(int perm)
 	state->egid = user_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setresgid(ID(rgid), ID(egid), ID(sgid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setresgid(%d, %d, %d)",
-		(int)ID(rgid), (int)ID(egid), (int)ID(sgid));
+		"PERM_USER: setresgid(%u, %u, %u)",
+		(unsigned int)ID(rgid), (unsigned int)ID(egid), (unsigned int)ID(sgid));
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -216,13 +216,13 @@ set_perms(int perm)
 	state->euid = user_uid;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setresuid(%d, %d, %d)",
-		(int)ID(ruid), (int)ID(euid), (int)ID(suid));
+		"PERM_USER: setresuid(%u, %u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid), (unsigned int)ID(suid));
 	    goto bad;
 	}
 	break;
@@ -233,13 +233,13 @@ set_perms(int perm)
 	state->egid = user_gid;
 	state->sgid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setresgid(ID(rgid), ID(egid), ID(sgid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setresgid(%d, %d, %d)",
-		(int)ID(rgid), (int)ID(egid), (int)ID(sgid));
+		"PERM_FULL_USER: setresgid(%u, %u, %u)",
+		(unsigned int)ID(rgid), (unsigned int)ID(egid), (unsigned int)ID(sgid));
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -254,13 +254,13 @@ set_perms(int perm)
 	state->euid = user_uid;
 	state->suid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setresuid(%d, %d, %d)",
-		(int)ID(ruid), (int)ID(euid), (int)ID(suid));
+		"PERM_FULL_USER: setresuid(%u, %u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid), (unsigned int)ID(suid));
 	    goto bad;
 	}
 	break;
@@ -270,9 +270,9 @@ set_perms(int perm)
 	state->egid = runas_gr ? runas_gr->gr_gid : runas_pw->pw_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setresgid(ID(rgid), ID(egid), ID(sgid))) {
 	    errstr = N_("unable to change to runas gid");
 	    goto bad;
@@ -286,9 +286,9 @@ set_perms(int perm)
 	state->euid = runas_pw ? runas_pw->pw_uid : user_uid;
 	state->suid = ostate->suid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    errstr = N_("unable to change to runas uid");
 	    goto bad;
@@ -308,9 +308,9 @@ set_perms(int perm)
 	state->egid = sudoers_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setresgid(ID(rgid), ID(egid), ID(sgid))) {
 	    errstr = N_("unable to change to sudoers gid");
 	    goto bad;
@@ -328,13 +328,13 @@ set_perms(int perm)
 	    state->euid = sudoers_uid;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_SUDOERS: setresuid(%d, %d, %d)",
-		(int)ID(ruid), (int)ID(euid), (int)ID(suid));
+		"PERM_SUDOERS: setresuid(%u, %u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid), (unsigned int)ID(suid));
 	    goto bad;
 	}
 	break;
@@ -350,13 +350,13 @@ set_perms(int perm)
 	state->euid = timestamp_get_uid();
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_TIMESTAMP: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setresuid(ID(ruid), ID(euid), ID(suid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_TIMESTAMP: setresuid(%d, %d, %d)",
-		(int)ID(ruid), (int)ID(euid), (int)ID(suid));
+		"PERM_TIMESTAMP: setresuid(%u, %u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid), (unsigned int)ID(suid));
 	    goto bad;
 	}
 	break;
@@ -387,26 +387,26 @@ restore_perms(void)
     ostate = &perm_stack[perm_stack_depth - 2];
     perm_stack_depth--;
 
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%d, %d, %d] -> [%d, %d, %d]",
-	__func__, (int)state->ruid, (int)state->euid, (int)state->suid,
-	(int)ostate->ruid, (int)ostate->euid, (int)ostate->suid);
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%d, %d, %d] -> [%d, %d, %d]",
-	__func__, (int)state->rgid, (int)state->egid, (int)state->sgid,
-	(int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%u, %u, %u] -> [%u, %u, %u]",
+	__func__, (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+	(unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%u, %u, %u] -> [%u, %u, %u]",
+	__func__, (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+	(unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid);
 
     /* XXX - more cases here where euid != ruid */
     if (OID(euid) == ROOT_UID) {
 	if (setresuid(-1, ROOT_UID, -1)) {
-	    sudo_warn("setresuid() [%d, %d, %d] -> [%d, %d, %d]",
-		(int)state->ruid, (int)state->euid, (int)state->suid,
-		-1, ROOT_UID, -1);
+	    sudo_warn("setresuid() [%u, %u, %u] -> [-1, %u, -1]",
+		(unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+		ROOT_UID);
 	    goto bad;
 	}
     }
     if (setresgid(OID(rgid), OID(egid), OID(sgid))) {
-	sudo_warn("setresgid() [%d, %d, %d] -> [%d, %d, %d]",
-	    (int)state->rgid, (int)state->egid, (int)state->sgid,
-	    (int)OID(rgid), (int)OID(egid), (int)OID(sgid));
+	sudo_warn("setresgid() [%u, %u, %u] -> [%u, %u, %u]",
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+	    (unsigned int)OID(rgid), (unsigned int)OID(egid), (unsigned int)OID(sgid));
 	goto bad;
     }
     if (state->gidlist != ostate->gidlist) {
@@ -416,9 +416,9 @@ restore_perms(void)
 	}
     }
     if (setresuid(OID(ruid), OID(euid), OID(suid))) {
-	sudo_warn("setresuid() [%d, %d, %d] -> [%d, %d, %d]",
-	    (int)state->ruid, (int)state->euid, (int)state->suid,
-	    (int)OID(ruid), (int)OID(euid), (int)OID(suid));
+	sudo_warn("setresuid() [%u, %u, %u] -> [%u, %u, %u]",
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+	    (unsigned int)OID(ruid), (unsigned int)OID(euid), (unsigned int)OID(suid));
 	goto bad;
     }
     sudo_gidlist_delref(state->gidlist);
@@ -479,9 +479,9 @@ set_perms(int perm)
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_INITIAL: "
-	    "ruid: %d, euid: %d, suid: %d, rgid: %d, egid: %d, sgid: %d",
-	    __func__, (int)state->ruid, (int)state->euid, (int)state->suid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "ruid: %u, euid: %u, suid: %u, rgid: %u, egid: %u, sgid: %u",
+	    __func__, (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	break;
 
     case PERM_ROOT:
@@ -489,12 +489,12 @@ set_perms(int perm)
 	state->euid = ROOT_UID;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, ROOT_UID)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_ROOT: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
+		"PERM_ROOT: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
 		ROOT_UID);
 	    goto bad;
 	}
@@ -502,9 +502,9 @@ set_perms(int perm)
 	state->egid = ROOT_GID;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setgidx(ID_EFFECTIVE, ROOT_GID)) {
 	    errstr = N_("unable to change to root gid");
 	    goto bad;
@@ -518,12 +518,12 @@ set_perms(int perm)
 	state->egid = user_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setgidx(ID_EFFECTIVE, user_gid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setgidx(ID_EFFECTIVE, %d)", (int)user_gid);
+		"PERM_USER: setgidx(ID_EFFECTIVE, %u)", (unsigned int)user_gid);
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -538,20 +538,20 @@ set_perms(int perm)
 	state->euid = user_uid;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (ostate->euid != ROOT_UID || ostate->suid != ROOT_UID) {
 	    if (setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, ROOT_UID)) {
 		(void)snprintf(errbuf, sizeof(errbuf),
-		    "PERM_USER: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
+		    "PERM_USER: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
 		    ROOT_UID);
 		goto bad;
 	    }
 	}
 	if (setuidx(ID_EFFECTIVE|ID_REAL, user_uid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setuidx(ID_EFFECTIVE|ID_REAL, %d)", (int)user_uid);
+		"PERM_USER: setuidx(ID_EFFECTIVE|ID_REAL, %u)", (unsigned int)user_uid);
 	    goto bad;
 	}
 	break;
@@ -562,13 +562,13 @@ set_perms(int perm)
 	state->egid = user_gid;
 	state->sgid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, user_gid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
-		(int)user_gid);
+		"PERM_FULL_USER: setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
+		(unsigned int)user_gid);
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -583,13 +583,13 @@ set_perms(int perm)
 	state->euid = user_uid;
 	state->suid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, user_uid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
-		(int)user_uid);
+		"PERM_FULL_USER: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
+		(unsigned int)user_uid);
 	    goto bad;
 	}
 	break;
@@ -599,9 +599,9 @@ set_perms(int perm)
 	state->egid = runas_gr ? runas_gr->gr_gid : runas_pw->pw_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setgidx(ID_EFFECTIVE, state->egid)) {
 	    errstr = N_("unable to change to runas gid");
 	    goto bad;
@@ -615,9 +615,9 @@ set_perms(int perm)
 	state->euid = runas_pw ? runas_pw->pw_uid : user_uid;
 	state->suid = ostate->suid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED && setuidx(ID_EFFECTIVE, state->euid)) {
 	    errstr = N_("unable to change to runas uid");
 	    goto bad;
@@ -637,9 +637,9 @@ set_perms(int perm)
 	state->egid = sudoers_gid;
 	state->sgid = ostate->sgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: gid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid,
-	    (int)state->rgid, (int)state->egid, (int)state->sgid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid);
 	if (GID_CHANGED && setgidx(ID_EFFECTIVE, sudoers_gid)) {
 	    errstr = N_("unable to change to sudoers gid");
 	    goto bad;
@@ -657,21 +657,21 @@ set_perms(int perm)
 	    state->euid = sudoers_uid;
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED) {
 	    if (ostate->ruid != ROOT_UID || ostate->suid != ROOT_UID) {
 		if (setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, ROOT_UID)) {
 		    (void)snprintf(errbuf, sizeof(errbuf),
-			"PERM_SUDOERS: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
+			"PERM_SUDOERS: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
 			ROOT_UID);
 		    goto bad;
 		}
 	    }
 	    if (setuidx(ID_EFFECTIVE, state->euid)) {
 		(void)snprintf(errbuf, sizeof(errbuf),
-		    "PERM_SUDOERS: setuidx(ID_EFFECTIVE, %d)", (int)sudoers_uid);
+		    "PERM_SUDOERS: setuidx(ID_EFFECTIVE, %u)", (unsigned int)sudoers_uid);
 		goto bad;
 	    }
 	}
@@ -688,22 +688,22 @@ set_perms(int perm)
 	state->euid = timestamp_get_uid();
 	state->suid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_TIMESTAMP: uid: "
-	    "[%d, %d, %d] -> [%d, %d, %d]", __func__,
-	    (int)ostate->ruid, (int)ostate->euid, (int)ostate->suid,
-	    (int)state->ruid, (int)state->euid, (int)state->suid);
+	    "[%u, %u, %u] -> [%u, %u, %u]", __func__,
+	    (unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid,
+	    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid);
 	if (UID_CHANGED) {
 	    if (ostate->ruid != ROOT_UID || ostate->suid != ROOT_UID) {
 		if (setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, ROOT_UID)) {
 		    (void)snprintf(errbuf, sizeof(errbuf),
-			"PERM_TIMESTAMP: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
+			"PERM_TIMESTAMP: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
 			ROOT_UID);
 		    goto bad;
 		}
 	    }
 	    if (setuidx(ID_EFFECTIVE, state->euid)) {
 		(void)snprintf(errbuf, sizeof(errbuf),
-		    "PERM_TIMESTAMP: setuidx(ID_EFFECTIVE, %d)",
-		    (int)state->euid);
+		    "PERM_TIMESTAMP: setuidx(ID_EFFECTIVE, %u)",
+		    (unsigned int)state->euid);
 		goto bad;
 	    }
 	}
@@ -735,62 +735,62 @@ restore_perms(void)
     ostate = &perm_stack[perm_stack_depth - 2];
     perm_stack_depth--;
 
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%d, %d, %d] -> [%d, %d, %d]",
-	__func__, (int)state->ruid, (int)state->euid, (int)state->suid,
-	(int)ostate->ruid, (int)ostate->euid, (int)ostate->suid);
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%d, %d, %d] -> [%d, %d, %d]",
-	__func__, (int)state->rgid, (int)state->egid, (int)state->sgid,
-	(int)ostate->rgid, (int)ostate->egid, (int)ostate->sgid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%u, %u, %u] -> [%u, %u, %u]",
+	__func__, (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+	(unsigned int)ostate->ruid, (unsigned int)ostate->euid, (unsigned int)ostate->suid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%u, %u, %u] -> [%u, %u, %u]",
+	__func__, (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+	(unsigned int)ostate->rgid, (unsigned int)ostate->egid, (unsigned int)ostate->sgid);
 
     if (OID(ruid) != (uid_t)-1 || OID(euid) != (uid_t)-1 || OID(suid) != (uid_t)-1) {
 	if (OID(euid) == ROOT_UID) {
-	    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: setuidx(ID_EFFECTIVE, %d)",
+	    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: setuidx(ID_EFFECTIVE, %u)",
 		__func__, ROOT_UID);
 	    if (setuidx(ID_EFFECTIVE, ROOT_UID)) {
-		sudo_warn("setuidx(ID_EFFECTIVE) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->ruid, (int)state->euid, (int)state->suid,
-		    -1, ROOT_UID, -1);
+		sudo_warn("setuidx(ID_EFFECTIVE) [%u, %u, %u] -> [-1, %u, -1]",
+		    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+		    ROOT_UID);
 		goto bad;
 	    }
 	}
 	if (OID(ruid) == OID(euid) && OID(euid) == OID(suid)) {
 	    sudo_debug_printf(SUDO_DEBUG_INFO,
-		"%s: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
-		__func__, (int)OID(ruid));
+		"%s: setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
+		__func__, (unsigned int)OID(ruid));
 	    if (setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, OID(ruid))) {
-		sudo_warn("setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->ruid, (int)state->euid, (int)state->suid,
-		    (int)OID(ruid), (int)OID(euid), (int)OID(suid));
+		sudo_warn("setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED) [%u, %u, %u] -> [%u, %u, %u]",
+		    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+		    (unsigned int)OID(ruid), (unsigned int)OID(euid), (unsigned int)OID(suid));
 		goto bad;
 	    }
 	} else if (OID(ruid) == (uid_t)-1 && OID(suid) == (uid_t)-1) {
 	    /* May have already changed euid to ROOT_UID above. */
 	    if (OID(euid) != ROOT_UID) {
 		sudo_debug_printf(SUDO_DEBUG_INFO,
-		    "%s: setuidx(ID_EFFECTIVE, %d)", __func__, OID(euid));
+		    "%s: setuidx(ID_EFFECTIVE, %u)", __func__, (unsigned int)OID(euid));
 		if (setuidx(ID_EFFECTIVE, OID(euid))) {
-		    sudo_warn("setuidx(ID_EFFECTIVE) [%d, %d, %d] -> [%d, %d, %d]",
-			(int)state->ruid, (int)state->euid, (int)state->suid,
-			(int)OID(ruid), (int)OID(euid), (int)OID(suid));
+		    sudo_warn("setuidx(ID_EFFECTIVE) [%u, %u, %u] -> [%u, %u, %u]",
+			(unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+			(unsigned int)OID(ruid), (unsigned int)OID(euid), (unsigned int)OID(suid));
 		    goto bad;
 		}
 	    }
 	} else if (OID(suid) == (uid_t)-1) {
 	    /* Cannot set the real uid alone. */
 	    sudo_debug_printf(SUDO_DEBUG_INFO,
-		"%s: setuidx(ID_REAL|ID_EFFECTIVE, %d)", __func__, OID(ruid));
+		"%s: setuidx(ID_REAL|ID_EFFECTIVE, %u)", __func__, (unsigned int)OID(ruid));
 	    if (setuidx(ID_REAL|ID_EFFECTIVE, OID(ruid))) {
-		sudo_warn("setuidx(ID_REAL|ID_EFFECTIVE) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->ruid, (int)state->euid, (int)state->suid,
-		    (int)OID(ruid), (int)OID(euid), (int)OID(suid));
+		sudo_warn("setuidx(ID_REAL|ID_EFFECTIVE) [%u, %u, %u] -> [%u, %u, %u]",
+		    (unsigned int)state->ruid, (unsigned int)state->euid, (unsigned int)state->suid,
+		    (unsigned int)OID(ruid), (unsigned int)OID(euid), (unsigned int)OID(suid));
 		goto bad;
 	    }
 	    /* Restore the effective euid if it doesn't match the ruid. */
 	    if (OID(euid) != OID(ruid)) {
 		sudo_debug_printf(SUDO_DEBUG_INFO,
-		    "%s: setuidx(ID_EFFECTIVE, %d)", __func__, ostate->euid);
+		    "%s: setuidx(ID_EFFECTIVE, %u)", __func__, (unsigned int)ostate->euid);
 		if (setuidx(ID_EFFECTIVE, ostate->euid)) {
-		    sudo_warn("setuidx(ID_EFFECTIVE, %d)", (int)ostate->euid);
+		    sudo_warn("setuidx(ID_EFFECTIVE, %u)", (unsigned int)ostate->euid);
 		    goto bad;
 		}
 	    }
@@ -799,30 +799,30 @@ restore_perms(void)
     if (OID(rgid) != (gid_t)-1 || OID(egid) != (gid_t)-1 || OID(sgid) != (gid_t)-1) {
 	if (OID(rgid) == OID(egid) && OID(egid) == OID(sgid)) {
 	    sudo_debug_printf(SUDO_DEBUG_INFO,
-		"%s: setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %d)",
-		__func__, (int)OID(rgid));
+		"%s: setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, %u)",
+		__func__, (unsigned int)OID(rgid));
 	    if (setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED, OID(rgid))) {
-		sudo_warn("setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->rgid, (int)state->egid, (int)state->sgid,
-		    (int)OID(rgid), (int)OID(egid), (int)OID(sgid));
+		sudo_warn("setgidx(ID_EFFECTIVE|ID_REAL|ID_SAVED) [%u, %u, %u] -> [%u, %u, %u]",
+		    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+		    (unsigned int)OID(rgid), (unsigned int)OID(egid), (unsigned int)OID(sgid));
 		goto bad;
 	    }
 	} else if (OID(rgid) == (gid_t)-1 && OID(sgid) == (gid_t)-1) {
-	    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: setgidx(ID_EFFECTIVE, %d)",
-		__func__, (int)OID(egid));
+	    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: setgidx(ID_EFFECTIVE, %u)",
+		__func__, (unsigned int)OID(egid));
 	    if (setgidx(ID_EFFECTIVE, OID(egid))) {
-		sudo_warn("setgidx(ID_EFFECTIVE) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->rgid, (int)state->egid, (int)state->sgid,
-		    (int)OID(rgid), (int)OID(egid), (int)OID(sgid));
+		sudo_warn("setgidx(ID_EFFECTIVE) [%u, %u, %u] -> [%u, %u, %u]",
+		    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+		    (unsigned int)OID(rgid), (unsigned int)OID(egid), (unsigned int)OID(sgid));
 		goto bad;
 	    }
 	} else if (OID(sgid) == (gid_t)-1) {
 	    sudo_debug_printf(SUDO_DEBUG_INFO,
-		"%s: setgidx(ID_EFFECTIVE|ID_REAL, %d)", __func__, OID(rgid));
+		"%s: setgidx(ID_EFFECTIVE|ID_REAL, %u)", __func__, OID(rgid));
 	    if (setgidx(ID_REAL|ID_EFFECTIVE, OID(rgid))) {
-		sudo_warn("setgidx(ID_REAL|ID_EFFECTIVE) [%d, %d, %d] -> [%d, %d, %d]",
-		    (int)state->rgid, (int)state->egid, (int)state->sgid,
-		    (int)OID(rgid), (int)OID(egid), (int)OID(sgid));
+		sudo_warn("setgidx(ID_REAL|ID_EFFECTIVE) [%u, %u, %u] -> [%u, %u, %u]",
+		    (unsigned int)state->rgid, (unsigned int)state->egid, (unsigned int)state->sgid,
+		    (unsigned int)OID(rgid), (unsigned int)OID(egid), (unsigned int)OID(sgid));
 		goto bad;
 	    }
 	}
@@ -889,42 +889,42 @@ set_perms(int perm)
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_INITIAL: "
-	    "ruid: %d, euid: %d, rgid: %d, egid: %d", __func__,
-	    (int)state->ruid, (int)state->euid,
-	    (int)state->rgid, (int)state->egid);
+	    "ruid: %u, euid: %u, rgid: %u, egid: %u", __func__,
+	    (unsigned int)state->ruid, (unsigned int)state->euid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid);
 	break;
 
     case PERM_ROOT:
 	state->ruid = ROOT_UID;
 	state->euid = ROOT_UID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	/*
 	 * setreuid(0, 0) may fail on some systems if euid is not already 0.
 	 */
 	if (ostate->euid != ROOT_UID) {
 	    if (setreuid(-1, ROOT_UID)) {
 		(void)snprintf(errbuf, sizeof(errbuf),
-		    "PERM_ROOT: setreuid(-1, %d)", ROOT_UID);
+		    "PERM_ROOT: setreuid(-1, %u)", ROOT_UID);
 		goto bad;
 	    }
 	}
 	if (ostate->ruid != ROOT_UID) {
 	    if (setreuid(ROOT_UID, -1)) {
 		(void)snprintf(errbuf, sizeof(errbuf),
-		    "PERM_ROOT: setreuid(%d, -1)", ROOT_UID);
+		    "PERM_ROOT: setreuid(%u, -1)", ROOT_UID);
 		goto bad;
 	    }
 	}
 	state->rgid = ostate->rgid;
 	state->egid = ROOT_GID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setregid(ID(rgid), ID(egid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_ROOT: setregid(%d, %d)", (int)ID(rgid), (int)ID(egid));
+		"PERM_ROOT: setregid(%u, %u)", (unsigned int)ID(rgid), (unsigned int)ID(egid));
 	    goto bad;
 	}
 	state->gidlist = ostate->gidlist;
@@ -935,11 +935,11 @@ set_perms(int perm)
 	state->rgid = ostate->rgid;
 	state->egid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setregid(ID(rgid), ID(egid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setregid(%d, %d)", (int)ID(rgid), (int)ID(egid));
+		"PERM_USER: setregid(%u, %u)", (unsigned int)ID(rgid), (unsigned int)ID(egid));
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -953,11 +953,11 @@ set_perms(int perm)
 	state->ruid = ROOT_UID;
 	state->euid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (UID_CHANGED && setreuid(ID(ruid), ID(euid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setreuid(%d, %d)", (int)ID(ruid), (int)ID(euid));
+		"PERM_USER: setreuid(%u, %u)", (unsigned int)ID(ruid), (unsigned int)ID(euid));
 	    goto bad;
 	}
 	break;
@@ -967,12 +967,12 @@ set_perms(int perm)
 	state->rgid = user_gid;
 	state->egid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setregid(ID(rgid), ID(egid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setregid(%d, %d)",
-		(int)ID(rgid), (int)ID(egid));
+		"PERM_FULL_USER: setregid(%u, %u)",
+		(unsigned int)ID(rgid), (unsigned int)ID(egid));
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -986,12 +986,12 @@ set_perms(int perm)
 	state->ruid = user_uid;
 	state->euid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (UID_CHANGED && setreuid(ID(ruid), ID(euid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setreuid(%d, %d)",
-		(int)ID(ruid), (int)ID(euid));
+		"PERM_FULL_USER: setreuid(%u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid));
 	    goto bad;
 	}
 	break;
@@ -1000,8 +1000,8 @@ set_perms(int perm)
 	state->rgid = ostate->rgid;
 	state->egid = runas_gr ? runas_gr->gr_gid : runas_pw->pw_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setregid(ID(rgid), ID(egid))) {
 	    errstr = N_("unable to change to runas gid");
 	    goto bad;
@@ -1014,8 +1014,8 @@ set_perms(int perm)
 	state->ruid = ROOT_UID;
 	state->euid = runas_pw ? runas_pw->pw_uid : user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (UID_CHANGED && setreuid(ID(ruid), ID(euid))) {
 	    errstr = N_("unable to change to runas uid");
 	    goto bad;
@@ -1034,8 +1034,8 @@ set_perms(int perm)
 	state->rgid = ostate->rgid;
 	state->egid = sudoers_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setregid(ID(rgid), ID(egid))) {
 	    errstr = N_("unable to change to sudoers gid");
 	    goto bad;
@@ -1052,12 +1052,12 @@ set_perms(int perm)
 	else
 	    state->euid = sudoers_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (UID_CHANGED && setreuid(ID(ruid), ID(euid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_SUDOERS: setreuid(%d, %d)",
-		(int)ID(ruid), (int)ID(euid));
+		"PERM_SUDOERS: setreuid(%u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid));
 	    goto bad;
 	}
 	break;
@@ -1071,12 +1071,12 @@ set_perms(int perm)
 	state->ruid = ROOT_UID;
 	state->euid = timestamp_get_uid();
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_TIMESTAMP: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (UID_CHANGED && setreuid(ID(ruid), ID(euid))) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_TIMESTAMP: setreuid(%d, %d)",
-		(int)ID(ruid), (int)ID(euid));
+		"PERM_TIMESTAMP: setreuid(%u, %u)",
+		(unsigned int)ID(ruid), (unsigned int)ID(euid));
 	    goto bad;
 	}
 	break;
@@ -1107,12 +1107,12 @@ restore_perms(void)
     ostate = &perm_stack[perm_stack_depth - 2];
     perm_stack_depth--;
 
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%d, %d] -> [%d, %d]",
-	__func__, (int)state->ruid, (int)state->euid,
-	(int)ostate->ruid, (int)ostate->euid);
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%d, %d] -> [%d, %d]",
-	__func__, (int)state->rgid, (int)state->egid,
-	(int)ostate->rgid, (int)ostate->egid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%u, %u] -> [%u, %u]",
+	__func__, (unsigned int)state->ruid, (unsigned int)state->euid,
+	(unsigned int)ostate->ruid, (unsigned int)ostate->euid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%u, %u] -> [%u, %u]",
+	__func__, (unsigned int)state->rgid, (unsigned int)state->egid,
+	(unsigned int)ostate->rgid, (unsigned int)ostate->egid);
 
     /*
      * When changing euid to ROOT_UID, setreuid() may fail even if
@@ -1123,24 +1123,24 @@ restore_perms(void)
 	if (ID(euid) != ROOT_UID) {
 	    if (setreuid(-1, ROOT_UID) != 0) {
 		sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		    "setreuid() [%d, %d] -> [-1, %d)", (int)state->ruid,
-		    (int)state->euid, ROOT_UID);
+		    "setreuid() [%u, %u] -> [-1, %u)", (unsigned int)state->ruid,
+		    (unsigned int)state->euid, ROOT_UID);
 	    }
 	}
 	if (setuid(ROOT_UID)) {
-	    sudo_warn("setuid() [%d, %d] -> %d)", (int)state->ruid,
-		(int)state->euid, ROOT_UID);
+	    sudo_warn("setuid() [%u, %u] -> %u)", (unsigned int)state->ruid,
+		(unsigned int)state->euid, ROOT_UID);
 	    goto bad;
 	}
     }
     if (setreuid(OID(ruid), OID(euid))) {
-	sudo_warn("setreuid() [%d, %d] -> [%d, %d]", (int)state->ruid,
-	    (int)state->euid, (int)OID(ruid), (int)OID(euid));
+	sudo_warn("setreuid() [%u, %u] -> [%u, %u]", (unsigned int)state->ruid,
+	    (unsigned int)state->euid, (unsigned int)OID(ruid), (unsigned int)OID(euid));
 	goto bad;
     }
     if (setregid(OID(rgid), OID(egid))) {
-	sudo_warn("setregid() [%d, %d] -> [%d, %d]", (int)state->rgid,
-	    (int)state->egid, (int)OID(rgid), (int)OID(egid));
+	sudo_warn("setregid() [%u, %u] -> [%u, %u]", (unsigned int)state->rgid,
+	    (unsigned int)state->egid, (unsigned int)OID(rgid), (unsigned int)OID(egid));
 	goto bad;
     }
     if (state->gidlist != ostate->gidlist) {
@@ -1202,12 +1202,12 @@ set_perms(int perm)
     if (perm != PERM_INITIAL) {
 	if (ostate->euid != ROOT_UID && seteuid(ROOT_UID)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"set_perms: seteuid(%d)", ROOT_UID);
+		"set_perms: seteuid(%u)", ROOT_UID);
 	    goto bad;
 	}
 	if (ostate->ruid != ROOT_UID && setuid(ROOT_UID)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"set_perms: setuid(%d)", ROOT_UID);
+		"set_perms: setuid(%u)", ROOT_UID);
 	    goto bad;
 	}
     }
@@ -1222,23 +1222,23 @@ set_perms(int perm)
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_INITIAL: "
-	    "ruid: %d, euid: %d, rgid: %d, egid: %d", __func__,
-	    (int)state->ruid, (int)state->euid,
-	    (int)state->rgid, (int)state->egid);
+	    "ruid: %u, euid: %u, rgid: %u, egid: %u", __func__,
+	    (unsigned int)state->ruid, (unsigned int)state->euid,
+	    (unsigned int)state->rgid, (unsigned int)state->egid);
 	break;
 
     case PERM_ROOT:
 	/* We already set ruid/euid above. */
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, ROOT_UID, ROOT_UID);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, ROOT_UID, ROOT_UID);
 	state->ruid = ROOT_UID;
 	state->euid = ROOT_UID;
 	state->rgid = ostate->rgid;
 	state->egid = ROOT_GID;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, ROOT_GID, ROOT_GID);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, ROOT_GID, ROOT_GID);
 	if (GID_CHANGED && setegid(ROOT_GID)) {
 	    errstr = N_("unable to change to root gid");
 	    goto bad;
@@ -1251,11 +1251,11 @@ set_perms(int perm)
 	state->egid = user_gid;
 	state->rgid = ostate->rgid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setegid(user_gid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: setegid(%d)", (int)user_gid);
+		"PERM_USER: setegid(%u)", (unsigned int)user_gid);
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -1269,11 +1269,11 @@ set_perms(int perm)
 	state->ruid = ROOT_UID;
 	state->euid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_USER: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (seteuid(user_uid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_USER: seteuid(%d)", (int)user_uid);
+		"PERM_USER: seteuid(%u)", (unsigned int)user_uid);
 	    goto bad;
 	}
 	break;
@@ -1283,11 +1283,11 @@ set_perms(int perm)
 	state->rgid = user_gid;
 	state->egid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setgid(user_gid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setgid(%d)", (int)user_gid);
+		"PERM_FULL_USER: setgid(%u)", (unsigned int)user_gid);
 	    goto bad;
 	}
 	state->gidlist = user_gid_list;
@@ -1301,11 +1301,11 @@ set_perms(int perm)
 	state->ruid = user_uid;
 	state->euid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (setuid(user_uid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setuid(%d)", (int)user_uid);
+		"PERM_FULL_USER: setuid(%u)", (unsigned int)user_uid);
 	    goto bad;
 	}
 	break;
@@ -1314,8 +1314,8 @@ set_perms(int perm)
 	state->rgid = ostate->rgid;
 	state->egid = runas_gr ? runas_gr->gr_gid : runas_pw->pw_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setegid(state->egid)) {
 	    errstr = N_("unable to change to runas gid");
 	    goto bad;
@@ -1328,8 +1328,8 @@ set_perms(int perm)
 	state->ruid = ostate->ruid;
 	state->euid = runas_pw ? runas_pw->pw_uid : user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_RUNAS: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (seteuid(state->euid)) {
 	    errstr = N_("unable to change to runas uid");
 	    goto bad;
@@ -1348,8 +1348,8 @@ set_perms(int perm)
 	state->rgid = ostate->rgid;
 	state->egid = sudoers_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: gid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->rgid,
-	    (int)ostate->egid, (int)state->rgid, (int)state->egid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->rgid,
+	    (unsigned int)ostate->egid, (unsigned int)state->rgid, (unsigned int)state->egid);
 	if (GID_CHANGED && setegid(sudoers_gid)) {
 	    errstr = N_("unable to change to sudoers gid");
 	    goto bad;
@@ -1366,11 +1366,11 @@ set_perms(int perm)
 	else
 	    state->euid = sudoers_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_SUDOERS: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (seteuid(state->euid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_SUDOERS: seteuid(%d)", (int)state->euid);
+		"PERM_SUDOERS: seteuid(%u)", (unsigned int)state->euid);
 	    goto bad;
 	}
 	break;
@@ -1384,11 +1384,11 @@ set_perms(int perm)
 	state->ruid = ROOT_UID;
 	state->euid = timestamp_get_uid();
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_TIMESTAMP: uid: "
-	    "[%d, %d] -> [%d, %d]", __func__, (int)ostate->ruid,
-	    (int)ostate->euid, (int)state->ruid, (int)state->euid);
+	    "[%u, %u] -> [%u, %u]", __func__, (unsigned int)ostate->ruid,
+	    (unsigned int)ostate->euid, (unsigned int)state->ruid, (unsigned int)state->euid);
 	if (seteuid(state->euid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_TIMESTAMP: seteuid(%d)", (int)state->euid);
+		"PERM_TIMESTAMP: seteuid(%u)", (unsigned int)state->euid);
 	    goto bad;
 	}
 	break;
@@ -1419,12 +1419,12 @@ restore_perms(void)
     ostate = &perm_stack[perm_stack_depth - 2];
     perm_stack_depth--;
 
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%d, %d] -> [%d, %d]",
-	__func__, (int)state->ruid, (int)state->euid,
-	(int)ostate->ruid, (int)ostate->euid);
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%d, %d] -> [%d, %d]",
-	__func__, (int)state->rgid, (int)state->egid,
-	(int)ostate->rgid, (int)ostate->egid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%u, %u] -> [%u, %u]",
+	__func__, (unsigned int)state->ruid, (unsigned int)state->euid,
+	(unsigned int)ostate->ruid, (unsigned int)ostate->euid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%u, %u] -> [%u, %u]",
+	__func__, (unsigned int)state->rgid, (unsigned int)state->egid,
+	(unsigned int)ostate->rgid, (unsigned int)ostate->egid);
 
     /*
      * Since we only have setuid() and seteuid() and semantics
@@ -1432,17 +1432,17 @@ restore_perms(void)
      * real and effective uids to ROOT_UID initially to be safe.
      */
     if (seteuid(ROOT_UID)) {
-	sudo_warn("seteuid() [%d] -> [%d]", (int)state->euid, ROOT_UID);
+	sudo_warn("seteuid() [%u] -> [%u]", (unsigned int)state->euid, ROOT_UID);
 	goto bad;
     }
     if (setuid(ROOT_UID)) {
-	sudo_warn("setuid() [%d, %d] -> [%d, %d]", (int)state->ruid, ROOT_UID,
+	sudo_warn("setuid() [%u, %u] -> [%u, %u]", (unsigned int)state->ruid, ROOT_UID,
 	    ROOT_UID, ROOT_UID);
 	goto bad;
     }
 
     if (OID(egid) != (gid_t)-1 && setegid(ostate->egid)) {
-	sudo_warn("setegid(%d)", (int)ostate->egid);
+	sudo_warn("setegid(%u)", (unsigned int)ostate->egid);
 	goto bad;
     }
     if (state->gidlist != ostate->gidlist) {
@@ -1452,7 +1452,7 @@ restore_perms(void)
 	}
     }
     if (OID(euid) != (uid_t)-1 && seteuid(ostate->euid)) {
-	sudo_warn("seteuid(%d)", (int)ostate->euid);
+	sudo_warn("seteuid(%u)", (unsigned int)ostate->euid);
 	goto bad;
     }
     sudo_gidlist_delref(state->gidlist);
@@ -1505,7 +1505,7 @@ set_perms(int perm)
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_INITIAL: "
-	    "ruid: %d, rgid: %d", __func__, (int)state->ruid, (int)state->rgid);
+	    "ruid: %u, rgid: %u", __func__, (unsigned int)state->ruid, (unsigned int)state->rgid);
 	break;
 
     case PERM_ROOT:
@@ -1514,14 +1514,14 @@ set_perms(int perm)
 	state->gidlist = ostate->gidlist;
 	sudo_gidlist_addref(state->gidlist);
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: uid: "
-	    "[%d] -> [%d]", __func__, (int)ostate->ruid, (int)state->ruid);
+	    "[%u] -> [%u]", __func__, (unsigned int)ostate->ruid, (unsigned int)state->ruid);
 	if (setuid(ROOT_UID)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_ROOT: setuid(%d)", ROOT_UID);
+		"PERM_ROOT: setuid(%u)", ROOT_UID);
 	    goto bad;
 	}
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_ROOT: gid: "
-	    "[%d] -> [%d]", __func__, (int)ostate->rgid, (int)state->rgid);
+	    "[%u] -> [%u]", __func__, (unsigned int)ostate->rgid, (unsigned int)state->rgid);
 	if (setgid(ROOT_GID)) {
 	    errstr = N_("unable to change to root gid");
 	    goto bad;
@@ -1531,7 +1531,7 @@ set_perms(int perm)
     case PERM_FULL_USER:
 	state->rgid = user_gid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: gid: "
-	    "[%d] -> [%d]", __func__, (int)ostate->rgid, (int)state->rgid);
+	    "[%u] -> [%u]", __func__, (unsigned int)ostate->rgid, (unsigned int)state->rgid);
 	(void) setgid(user_gid);
 	state->gidlist = user_gid_list;
 	sudo_gidlist_addref(state->gidlist);
@@ -1543,10 +1543,10 @@ set_perms(int perm)
 	}
 	state->ruid = user_uid;
 	sudo_debug_printf(SUDO_DEBUG_INFO, "%s: PERM_FULL_USER: uid: "
-	    "[%d] -> [%d]", __func__, (int)ostate->ruid, (int)state->ruid);
+	    "[%u] -> [%u]", __func__, (unsigned int)ostate->ruid, (unsigned int)state->ruid);
 	if (setuid(user_uid)) {
 	    (void)snprintf(errbuf, sizeof(errbuf),
-		"PERM_FULL_USER: setuid(%d)", (int)user_uid);
+		"PERM_FULL_USER: setuid(%u)", (unsigned int)user_uid);
 	    goto bad;
 	}
 	break;
@@ -1588,13 +1588,13 @@ restore_perms(void)
     ostate = &perm_stack[perm_stack_depth - 2];
     perm_stack_depth--;
 
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%d] -> [%d]",
-	__func__, (int)state->ruid, (int)ostate->ruid);
-    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%d] -> [%d]",
-	__func__, (int)state->rgid, (int)ostate->rgid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: uid: [%u] -> [%u]",
+	__func__, (unsigned int)state->ruid, (unsigned int)ostate->ruid);
+    sudo_debug_printf(SUDO_DEBUG_INFO, "%s: gid: [%u] -> [%u]",
+	__func__, (unsigned int)state->rgid, (unsigned int)ostate->rgid);
 
     if (OID(rgid) != (gid_t)-1 && setgid(ostate->rgid)) {
-	sudo_warn("setgid(%d)", (int)ostate->rgid);
+	sudo_warn("setgid(%u)", (unsigned int)ostate->rgid);
 	goto bad;
     }
     if (state->gidlist != ostate->gidlist) {
@@ -1605,7 +1605,7 @@ restore_perms(void)
     }
     sudo_gidlist_delref(state->gidlist);
     if (OID(ruid) != (uid_t)-1 && setuid(ostate->ruid)) {
-	sudo_warn("setuid(%d)", (int)ostate->ruid);
+	sudo_warn("setuid(%u)", (unsigned int)ostate->ruid);
 	goto bad;
     }
     debug_return_bool(true);

--- a/plugins/sudoers/timestamp.c
+++ b/plugins/sudoers/timestamp.c
@@ -127,7 +127,7 @@ ts_match_record(struct timestamp_entry *key, struct timestamp_entry *entry,
 	/* verify parent pid */
 	if (entry->u.ppid != key->u.ppid) {
 	    sudo_debug_printf(SUDO_DEBUG_DEBUG,
-		"%s:%u record ppid mismatch (want %d, got %d)", __func__, recno,
+		"%s:%u record ppid mismatch (want %u, got %u)", __func__, recno,
 		(int)key->u.ppid, (int)entry->u.ppid);
 	    debug_return_bool(false);
 	}
@@ -187,8 +187,8 @@ ts_find_record(int fd, struct timestamp_entry *key, struct timestamp_entry *entr
 		cur.size, sizeof(cur));
 	    if (lseek(fd, (off_t)cur.size - (off_t)sizeof(cur), SEEK_CUR) == -1) {
 		sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO|SUDO_DEBUG_LINENO,
-		    "unable to seek forward %d",
-		    (int)cur.size - (int)sizeof(cur));
+		    "unable to seek forward %zd",
+		    cur.size - ssizeof(cur));
 		break;
 	    }
 	    if (cur.size == 0)
@@ -227,8 +227,8 @@ ts_mkdirs(const char *path, uid_t owner, gid_t group, mode_t mode,
     if (parentfd != -1) {
 	/* Create final path component. */
 	sudo_debug_printf(SUDO_DEBUG_DEBUG|SUDO_DEBUG_LINENO,
-	    "mkdir %s, mode 0%o, uid %d, gid %d", path, (unsigned int)mode,
-	    (int)owner, (int)group);
+	    "mkdir %s, mode 0%o, uid %u, gid %u", path, (int)mode,
+	    (unsigned int)owner, (unsigned int)group);
 	if (mkdirat(parentfd, base, mode) != 0 && errno != EEXIST) {
 	    if (!quiet)
 		sudo_warn(U_("unable to mkdir %s"), path);
@@ -239,8 +239,8 @@ ts_mkdirs(const char *path, uid_t owner, gid_t group, mode_t mode,
 		    "%s: unable to open %s", __func__, path);
 	    } else if (fchown(fd, owner, group) != 0) {
 		sudo_debug_printf(SUDO_DEBUG_ERROR|SUDO_DEBUG_ERRNO,
-		    "%s: unable to chown %d:%d %s", __func__,
-		    (int)owner, (int)group, path);
+		    "%s: unable to chown %u:%u %s", __func__,
+		    (unsigned int)owner, (unsigned int)group, path);
 	    }
 	}
 	close(parentfd);

--- a/plugins/sudoers/toke.c
+++ b/plugins/sudoers/toke.c
@@ -5,7 +5,7 @@
 
 #include <config.h>
 
-#line 3 "toke.c"
+#line 2 "toke.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -3346,10 +3346,10 @@ int (*trace_print)(const char *msg) = sudoers_trace_print;
 	yyless(n);						\
 } while (0);
 
-#line 3344 "toke.c"
+#line 3343 "toke.c"
 #define YY_NO_INPUT 1
 
-#line 3347 "toke.c"
+#line 3346 "toke.c"
 
 #define INITIAL 0
 #define GOTDEFS 1
@@ -3578,7 +3578,7 @@ YY_DECL
 	{
 #line 119 "toke.l"
 
-#line 3576 "toke.c"
+#line 3575 "toke.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -4715,7 +4715,7 @@ YY_RULE_SETUP
 #line 909 "toke.l"
 ECHO;
 	YY_BREAK
-#line 4713 "toke.c"
+#line 4712 "toke.c"
 
 	case YY_END_OF_BUFFER:
 		{

--- a/plugins/sudoers/tsgetgrpw.c
+++ b/plugins/sudoers/tsgetgrpw.c
@@ -350,13 +350,14 @@ testsudoers_getgrouplist2_v1(const char *name, GETGROUPS_T basegid,
     GETGROUPS_T **groupsp, int *ngroupsp)
 {
     GETGROUPS_T *groups = *groupsp;
-    int i, grpsize, ngroups = 1;
+    int i, ngroups = 1;
+    long grpsize;
     int ret = -1;
     struct group *grp;
 
     if (groups == NULL) {
 	/* Dynamically-sized group vector. */
-	grpsize = (int)sysconf(_SC_NGROUPS_MAX);
+	grpsize = sysconf(_SC_NGROUPS_MAX);
 	if (grpsize < 0)
 	    grpsize = NGROUPS_MAX;
 	groups = reallocarray(NULL, grpsize, 4 * sizeof(*groups));

--- a/src/edit_open.c
+++ b/src/edit_open.c
@@ -62,7 +62,7 @@ switch_user_int(uid_t euid, gid_t egid, int ngroups, GETGROUPS_T *groups,
     if (setegid(egid) != 0) {
 	if (nonfatal)
 	    goto done;
-	sudo_fatal("setegid(%d)", (int)egid);
+	sudo_fatal("setegid(%u)", (unsigned int)egid);
     }
     if (ngroups != -1) {
 	if (sudo_setgroups(ngroups, groups) != 0) {

--- a/src/sudo.c
+++ b/src/sudo.c
@@ -437,7 +437,7 @@ get_user_groups(const char *user, struct sudo_cred *cred)
     cred->groups = NULL;
     group_source = sudo_conf_group_source();
     if (group_source != GROUP_SOURCE_DYNAMIC) {
-	int maxgroups = (int)sysconf(_SC_NGROUPS_MAX);
+	long maxgroups = sysconf(_SC_NGROUPS_MAX);
 	if (maxgroups < 0)
 	    maxgroups = NGROUPS_MAX;
 


### PR DESCRIPTION
gid and uid are unsigned on most platforms, and mode_t, being unsigned short but also passed as an int to some functions, are best passed cast to an integer.