### PR TITLE
Fix fuzzing errors

### DIFF
--- a/lib/util/roundup.c
+++ b/lib/util/roundup.c
@@ -47,14 +47,10 @@ sudo_pow2_roundup_v2(size_t len)
 {
     if (len < 64)
 	return 64;
-    len--;
-    len |= len >> 1;
-    len |= len >> 2;
-    len |= len >> 4;
-    len |= len >> 8;
-    len |= len >> 16;
+
 #ifdef __LP64__
-    len |= len >> 32;
+    return 1 << (64 - __builtin_clzl(len - 1));
+#else
+    return 1 << (32 - __builtin_clz(len - 1));
 #endif
-    return ++len;
 }

--- a/logsrvd/logsrvd_journal.c
+++ b/logsrvd/logsrvd_journal.c
@@ -270,11 +270,13 @@ journal_seek(struct timespec *target, struct connection_closure *closure)
 		bufsize = sudo_pow2_roundup(msg_len);
 		if (bufsize < msg_len) {
 		    /* overflow */
+		    errno = ENOMEM;
 		    closure->errstr = _("unable to allocate memory");
 		    break;
 		}
 		free(buf);
 		if ((buf = malloc(bufsize)) == NULL) {
+		    errno = ENOMEM;
 		    closure->errstr = _("unable to allocate memory");
 		    break;
 		}


### PR DESCRIPTION
We should be checking for integer overflow, rather than checking if size is 0.

Additionally, we should set errno to ENOMEM when this overflow happens.

Finally, the most efficient implementation of the round-up-to-2 algorithm involves the clz intrinsic.