### PR TITLE
Give every printf-like function restrict qualifiers

### DIFF
--- a/include/sudo_compat.h
+++ b/include/sudo_compat.h
@@ -422,32 +422,32 @@ sudo_dso_public int sudo_futimens(int fd, const struct timespec *times);
 # define futimens(_a, _b) sudo_futimens((_a), (_b))
 #endif /* HAVE_FUTIMENS */
 #if !defined(HAVE_SNPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
-sudo_dso_public int sudo_snprintf(char *str, size_t n, char const *fmt, ...) sudo_printflike(3, 4);
+sudo_dso_public int sudo_snprintf(char * restrict str, size_t n, char const * restrict fmt, ...) sudo_printflike(3, 4);
 # undef snprintf
 # define snprintf sudo_snprintf
 #endif /* HAVE_SNPRINTF */
 #if !defined(HAVE_VSNPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
-sudo_dso_public int sudo_vsnprintf(char *str, size_t n, const char *fmt, va_list ap) sudo_printflike(3, 0);
+sudo_dso_public int sudo_vsnprintf(char * restrict str, size_t n, const char * restrict fmt, va_list ap) sudo_printflike(3, 0);
 # undef vsnprintf
 # define vsnprintf sudo_vsnprintf
 #endif /* HAVE_VSNPRINTF */
 #if !defined(HAVE_ASPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
-sudo_dso_public int sudo_asprintf(char **str, char const *fmt, ...) sudo_printflike(2, 3);
+sudo_dso_public int sudo_asprintf(char ** restrict str, char const * restrict fmt, ...) sudo_printflike(2, 3);
 # undef asprintf
 # define asprintf sudo_asprintf
 #endif /* HAVE_ASPRINTF */
 #if !defined(HAVE_VASPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
-sudo_dso_public int sudo_vasprintf(char **str, const char *fmt, va_list ap) sudo_printflike(2, 0);
+sudo_dso_public int sudo_vasprintf(char ** restrict str, const char * restrict fmt, va_list ap) sudo_printflike(2, 0);
 # undef vasprintf
 # define vasprintf sudo_vasprintf
 #endif /* HAVE_VASPRINTF */
 #ifndef HAVE_STRLCAT
-sudo_dso_public size_t sudo_strlcat(char *dst, const char *src, size_t siz);
+sudo_dso_public size_t sudo_strlcat(char * restrict dst, const char * restrict src, size_t siz);
 # undef strlcat
 # define strlcat(_a, _b, _c) sudo_strlcat((_a), (_b), (_c))
 #endif /* HAVE_STRLCAT */
 #ifndef HAVE_STRLCPY
-sudo_dso_public size_t sudo_strlcpy(char *dst, const char *src, size_t siz);
+sudo_dso_public size_t sudo_strlcpy(char * restrict dst, const char * restrict src, size_t siz);
 # undef strlcpy
 # define strlcpy(_a, _b, _c) sudo_strlcpy((_a), (_b), (_c))
 #endif /* HAVE_STRLCPY */

--- a/include/sudo_debug.h
+++ b/include/sudo_debug.h
@@ -274,13 +274,13 @@ sudo_dso_public int sudo_debug_get_active_instance_v1(void);
 sudo_dso_public int sudo_debug_get_fds_v1(unsigned char **fds);
 sudo_dso_public int sudo_debug_get_instance_v1(const char *program);
 sudo_dso_public int sudo_debug_parse_flags_v1(struct sudo_conf_debug_file_list *debug_files, const char *entry);
-sudo_dso_public void sudo_debug_printf2_v1(const char *func, const char *file, int line, unsigned int level, const char *fmt, ...) sudo_printf0like(5, 6);
-sudo_dso_public void sudo_debug_printf_nvm_v1(int pri, const char *fmt, ...) sudo_printf0like(2, 3);
+sudo_dso_public void sudo_debug_printf2_v1(const char *func, const char *file, int line, unsigned int level, const char * restrict fmt, ...) sudo_printf0like(5, 6);
+sudo_dso_public void sudo_debug_printf_nvm_v1(int pri, const char * restrict fmt, ...) sudo_printf0like(2, 3);
 sudo_dso_public int sudo_debug_register_v1(const char *program, const char *const subsystems[], unsigned int ids[], struct sudo_conf_debug_file_list *debug_files);
 sudo_dso_public int sudo_debug_register_v2(const char *program, const char *const subsystems[], unsigned int ids[], struct sudo_conf_debug_file_list *debug_files, int minfd);
 sudo_dso_public int sudo_debug_set_active_instance_v1(int inst);
 sudo_dso_public void sudo_debug_update_fd_v1(int ofd, int nfd);
-sudo_dso_public void sudo_debug_vprintf2_v1(const char *func, const char *file, int line, unsigned int level, const char *fmt, va_list ap) sudo_printf0like(5, 0);
+sudo_dso_public void sudo_debug_vprintf2_v1(const char *func, const char *file, int line, unsigned int level, const char * restrict fmt, va_list ap) sudo_printf0like(5, 0);
 sudo_dso_public void sudo_debug_write2_v1(int fd, const char *func, const char *file, int line, const char *str, unsigned int len, int errnum);
 sudo_dso_public bool sudo_debug_needed_v1(unsigned int level);
 

--- a/include/sudo_fatal.h
+++ b/include/sudo_fatal.h
@@ -171,18 +171,18 @@ sudo_dso_public int  sudo_fatal_callback_deregister_v1(sudo_fatal_callback_t fun
 sudo_dso_public int  sudo_fatal_callback_register_v1(sudo_fatal_callback_t func);
 sudo_dso_public char *sudo_warn_gettext_v1(const char *domainname, const char *msgid) sudo_attr_fmt_arg(2);
 sudo_dso_public void sudo_warn_set_locale_func_v1(sudo_warn_setlocale_t func);
-sudo_noreturn sudo_dso_public void sudo_fatal_nodebug_v1(const char *fmt, ...) sudo_printf0like(1, 2);
-sudo_noreturn sudo_dso_public void sudo_fatalx_nodebug_v1(const char *fmt, ...) sudo_printflike(1, 2);
-sudo_noreturn sudo_dso_public void sudo_gai_fatal_nodebug_v1(int errnum, const char *fmt, ...) sudo_printflike(2, 3);
-sudo_noreturn sudo_dso_public void sudo_vfatal_nodebug_v1(const char *fmt, va_list ap) sudo_printf0like(1, 0);
-sudo_noreturn sudo_dso_public void sudo_vfatalx_nodebug_v1(const char *fmt, va_list ap) sudo_printflike(1, 0);
-sudo_noreturn sudo_dso_public void sudo_gai_vfatal_nodebug_v1(int errnum, const char *fmt, va_list ap) sudo_printflike(2, 0);
-sudo_dso_public void sudo_warn_nodebug_v1(const char *fmt, ...) sudo_printf0like(1, 2);
-sudo_dso_public void sudo_warnx_nodebug_v1(const char *fmt, ...) sudo_printflike(1, 2);
-sudo_dso_public void sudo_gai_warn_nodebug_v1(int errnum, const char *fmt, ...) sudo_printflike(2, 3);
-sudo_dso_public void sudo_vwarn_nodebug_v1(const char *fmt, va_list ap) sudo_printf0like(1, 0);
-sudo_dso_public void sudo_vwarnx_nodebug_v1(const char *fmt, va_list ap) sudo_printflike(1, 0);
-sudo_dso_public void sudo_gai_vwarn_nodebug_v1(int errnum, const char *fmt, va_list ap) sudo_printflike(2, 0);
+sudo_noreturn sudo_dso_public void sudo_fatal_nodebug_v1(const char * restrict fmt, ...) sudo_printf0like(1, 2);
+sudo_noreturn sudo_dso_public void sudo_fatalx_nodebug_v1(const char * restrict fmt, ...) sudo_printflike(1, 2);
+sudo_noreturn sudo_dso_public void sudo_gai_fatal_nodebug_v1(int errnum, const char * restrict fmt, ...) sudo_printflike(2, 3);
+sudo_noreturn sudo_dso_public void sudo_vfatal_nodebug_v1(const char * restrict fmt, va_list ap) sudo_printf0like(1, 0);
+sudo_noreturn sudo_dso_public void sudo_vfatalx_nodebug_v1(const char * restrict fmt, va_list ap) sudo_printflike(1, 0);
+sudo_noreturn sudo_dso_public void sudo_gai_vfatal_nodebug_v1(int errnum, const char * restrict fmt, va_list ap) sudo_printflike(2, 0);
+sudo_dso_public void sudo_warn_nodebug_v1(const char * restrict fmt, ...) sudo_printf0like(1, 2);
+sudo_dso_public void sudo_warnx_nodebug_v1(const char * restrict fmt, ...) sudo_printflike(1, 2);
+sudo_dso_public void sudo_gai_warn_nodebug_v1(int errnum, const char * restrict fmt, ...) sudo_printflike(2, 3);
+sudo_dso_public void sudo_vwarn_nodebug_v1(const char * restrict fmt, va_list ap) sudo_printf0like(1, 0);
+sudo_dso_public void sudo_vwarnx_nodebug_v1(const char * restrict fmt, va_list ap) sudo_printflike(1, 0);
+sudo_dso_public void sudo_gai_vwarn_nodebug_v1(int errnum, const char * restrict fmt, va_list ap) sudo_printflike(2, 0);
 sudo_dso_public void sudo_warn_set_conversation_v1(sudo_conv_t conv);
 
 #define sudo_fatal_callback_deregister(_a) sudo_fatal_callback_deregister_v1((_a))

--- a/include/sudo_lbuf.h
+++ b/include/sudo_lbuf.h
@@ -43,9 +43,9 @@ typedef int (*sudo_lbuf_output_t)(const char *);
 
 sudo_dso_public void sudo_lbuf_init_v1(struct sudo_lbuf *lbuf, sudo_lbuf_output_t output, unsigned int indent, const char *continuation, int cols);
 sudo_dso_public void sudo_lbuf_destroy_v1(struct sudo_lbuf *lbuf);
-sudo_dso_public bool sudo_lbuf_append_v1(struct sudo_lbuf *lbuf, const char *fmt, ...) sudo_printflike(2, 3);
-sudo_dso_public bool sudo_lbuf_append_esc_v1(struct sudo_lbuf *lbuf, int flags, const char *fmt, ...) sudo_printflike(3, 4);
-sudo_dso_public bool sudo_lbuf_append_quoted_v1(struct sudo_lbuf *lbuf, const char *set, const char *fmt, ...) sudo_printflike(3, 4);
+sudo_dso_public bool sudo_lbuf_append_v1(struct sudo_lbuf *lbuf, const char * restrict fmt, ...) sudo_printflike(2, 3);
+sudo_dso_public bool sudo_lbuf_append_esc_v1(struct sudo_lbuf *lbuf, int flags, const char * restrict fmt, ...) sudo_printflike(3, 4);
+sudo_dso_public bool sudo_lbuf_append_quoted_v1(struct sudo_lbuf *lbuf, const char *set, const char * restrict fmt, ...) sudo_printflike(3, 4);
 sudo_dso_public void sudo_lbuf_print_v1(struct sudo_lbuf *lbuf);
 sudo_dso_public bool sudo_lbuf_error_v1(struct sudo_lbuf *lbuf);
 sudo_dso_public void sudo_lbuf_clearerr_v1(struct sudo_lbuf *lbuf);

--- a/include/sudo_plugin.h
+++ b/include/sudo_plugin.h
@@ -85,7 +85,7 @@ struct sudo_conv_callback {
 
 typedef int (*sudo_conv_t)(int num_msgs, const struct sudo_conv_message msgs[],
 	struct sudo_conv_reply replies[], struct sudo_conv_callback *callback);
-typedef int (*sudo_printf_t)(int msg_type, const char *fmt, ...);
+typedef int (*sudo_printf_t)(int msg_type, const char * restrict fmt, ...);
 
 /*
  * Hooks allow a plugin to hook into specific sudo and/or libc functions.

--- a/include/sudo_util.h
+++ b/include/sudo_util.h
@@ -316,7 +316,7 @@ sudo_dso_public mode_t sudo_strtomode_v2(const char *cp, const char **errstr);
 #define sudo_strtomode(_a, _b) sudo_strtomode_v2((_a), (_b))
 
 /* sudo_printf.c */
-extern int (*sudo_printf)(int msg_type, const char *fmt, ...);
+extern int (*sudo_printf)(int msg_type, const char * restrict fmt, ...);
 
 /* term.c */
 sudo_dso_public bool sudo_term_cbreak_v1(int fd);

--- a/lib/eventlog/logwrap.c
+++ b/lib/eventlog/logwrap.c
@@ -33,7 +33,7 @@
 #include "sudo_eventlog.h"
 
 size_t
-eventlog_writeln(FILE *fp, char *line, size_t linelen, size_t maxlen)
+eventlog_writeln(FILE * restrict fp, char * restrict line, size_t linelen, size_t maxlen)
 {
     const char *indent = "";
     char *beg = line;

--- a/lib/util/fatal.c
+++ b/lib/util/fatal.c
@@ -57,7 +57,7 @@ static sudo_conv_t sudo_warn_conversation;
 static sudo_warn_setlocale_t sudo_warn_setlocale;
 static sudo_warn_setlocale_t sudo_warn_setlocale_prev;
 
-static void warning(const char *errstr, const char *fmt, va_list ap);
+static void warning(const char * restrict errstr, const char * restrict fmt, va_list ap);
 
 static void
 do_cleanup(void)
@@ -73,7 +73,7 @@ do_cleanup(void)
 }
 
 sudo_noreturn void
-sudo_fatal_nodebug_v1(const char *fmt, ...)
+sudo_fatal_nodebug_v1(const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -85,7 +85,7 @@ sudo_fatal_nodebug_v1(const char *fmt, ...)
 }
 
 sudo_noreturn void
-sudo_fatalx_nodebug_v1(const char *fmt, ...)
+sudo_fatalx_nodebug_v1(const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -97,7 +97,7 @@ sudo_fatalx_nodebug_v1(const char *fmt, ...)
 }
 
 sudo_noreturn void
-sudo_vfatal_nodebug_v1(const char *fmt, va_list ap)
+sudo_vfatal_nodebug_v1(const char * restrict fmt, va_list ap)
 {
     warning(strerror(errno), fmt, ap);
     do_cleanup();
@@ -105,7 +105,7 @@ sudo_vfatal_nodebug_v1(const char *fmt, va_list ap)
 }
 
 sudo_noreturn void
-sudo_vfatalx_nodebug_v1(const char *fmt, va_list ap)
+sudo_vfatalx_nodebug_v1(const char * restrict fmt, va_list ap)
 {
     warning(NULL, fmt, ap);
     do_cleanup();
@@ -113,7 +113,7 @@ sudo_vfatalx_nodebug_v1(const char *fmt, va_list ap)
 }
 
 void
-sudo_warn_nodebug_v1(const char *fmt, ...)
+sudo_warn_nodebug_v1(const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -123,7 +123,7 @@ sudo_warn_nodebug_v1(const char *fmt, ...)
 }
 
 void
-sudo_warnx_nodebug_v1(const char *fmt, ...)
+sudo_warnx_nodebug_v1(const char * restrict fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
@@ -132,19 +132,19 @@ sudo_warnx_nodebug_v1(const char *fmt, ...)
 }
 
 void
-sudo_vwarn_nodebug_v1(const char *fmt, va_list ap)
+sudo_vwarn_nodebug_v1(const char * restrict fmt, va_list ap)
 {
     warning(strerror(errno), fmt, ap);
 }
 
 void
-sudo_vwarnx_nodebug_v1(const char *fmt, va_list ap)
+sudo_vwarnx_nodebug_v1(const char * restrict fmt, va_list ap)
 {
     warning(NULL, fmt, ap);
 }
 
 sudo_noreturn void
-sudo_gai_fatal_nodebug_v1(int errnum, const char *fmt, ...)
+sudo_gai_fatal_nodebug_v1(int errnum, const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -156,7 +156,7 @@ sudo_gai_fatal_nodebug_v1(int errnum, const char *fmt, ...)
 }
 
 sudo_noreturn void
-sudo_gai_vfatal_nodebug_v1(int errnum, const char *fmt, va_list ap)
+sudo_gai_vfatal_nodebug_v1(int errnum, const char * restrict fmt, va_list ap)
 {
     warning(gai_strerror(errnum), fmt, ap);
     do_cleanup();
@@ -164,7 +164,7 @@ sudo_gai_vfatal_nodebug_v1(int errnum, const char *fmt, va_list ap)
 }
 
 void
-sudo_gai_warn_nodebug_v1(int errnum, const char *fmt, ...)
+sudo_gai_warn_nodebug_v1(int errnum, const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -174,13 +174,13 @@ sudo_gai_warn_nodebug_v1(int errnum, const char *fmt, ...)
 }
 
 void
-sudo_gai_vwarn_nodebug_v1(int errnum, const char *fmt, va_list ap)
+sudo_gai_vwarn_nodebug_v1(int errnum, const char * restrict fmt, va_list ap)
 {
     warning(gai_strerror(errnum), fmt, ap);
 }
 
 static void
-warning(const char *errstr, const char *fmt, va_list ap)
+warning(const char * restrict errstr, const char * restrict fmt, va_list ap)
 {
     int cookie;
     const int saved_errno = errno;

--- a/lib/util/inet_ntop.c
+++ b/lib/util/inet_ntop.c
@@ -70,7 +70,7 @@
  *	Paul Vixie, 1996.
  */
 static const char *
-inet_ntop4(const unsigned char *src, char *dst, socklen_t size)
+inet_ntop4(const unsigned char * restrict src, char * restrict dst, socklen_t size)
 {
 	const char fmt[] = "%u.%u.%u.%u";
 	int len;
@@ -91,7 +91,7 @@ inet_ntop4(const unsigned char *src, char *dst, socklen_t size)
  *	Paul Vixie, 1996.
  */
 static const char *
-inet_ntop6(const unsigned char *src, char *dst, socklen_t size)
+inet_ntop6(const unsigned char * restrict src, char * restrict dst, socklen_t size)
 {
 	/*
 	 * Note that int32_t and int16_t need only be "at least" large enough
@@ -210,7 +210,7 @@ inet_ntop6(const unsigned char *src, char *dst, socklen_t size)
  *	Paul Vixie, 1996.
  */
 const char *
-sudo_inet_ntop(int af, const void *src, char *dst, socklen_t size)
+sudo_inet_ntop(int af, const void * restrict src, char * restrict dst, socklen_t size)
 {
 	switch (af) {
 	case AF_INET:

--- a/lib/util/lbuf.c
+++ b/lib/util/lbuf.c
@@ -145,7 +145,7 @@ escape(char ch, char *buf)
  * Any non-printable characters are escaped in octal as #0nn.
  */
 bool
-sudo_lbuf_append_esc_v1(struct sudo_lbuf *lbuf, int flags, const char *fmt, ...)
+sudo_lbuf_append_esc_v1(struct sudo_lbuf *lbuf, int flags, const char * restrict fmt, ...)
 {
     unsigned int saved_len = lbuf->len;
     bool ret = false;
@@ -220,7 +220,7 @@ done:
  * Any characters in set are quoted with a backslash.
  */
 bool
-sudo_lbuf_append_quoted_v1(struct sudo_lbuf *lbuf, const char *set, const char *fmt, ...)
+sudo_lbuf_append_quoted_v1(struct sudo_lbuf *lbuf, const char *set, const char * restrict fmt, ...)
 {
     unsigned int saved_len = lbuf->len;
     bool ret = false;
@@ -279,7 +279,7 @@ done:
  * Parse the format and append strings, only %s, %n$s and %% escapes are supported.
  */
 bool
-sudo_lbuf_append_v1(struct sudo_lbuf *lbuf, const char *fmt, ...)
+sudo_lbuf_append_v1(struct sudo_lbuf *lbuf, const char * restrict fmt, ...)
 {
     unsigned int saved_len = lbuf->len;
     bool ret = false;

--- a/lib/util/snprintf.c
+++ b/lib/util/snprintf.c
@@ -106,9 +106,9 @@ union arg {
 #endif
 };
 
-static int __find_arguments(const char *fmt0, va_list ap, union arg **argtable);
+static int __find_arguments(const char * restrict fmt0, va_list ap, union arg **argtable);
 static int __grow_type_table(unsigned char **typetable, int *tablesize);
-static int xxxprintf(char **, size_t, int, const char *, va_list);
+static int xxxprintf(char ** restrict, size_t, int, const char * restrict, va_list);
 
 #ifdef PRINTF_WIDE_CHAR
 /*
@@ -224,7 +224,7 @@ static int exponent(char *, int, int);
  * Actual printf innards.
   */
 static int
-xxxprintf(char **strp, size_t strsize, int alloc, const char *fmt0, va_list ap)
+xxxprintf(char ** restrict strp, size_t strsize, int alloc, const char * restrict fmt0, va_list ap)
 {
 	char *fmt;		/* format string */
 	int ch;			/* character from fmt */
@@ -1484,7 +1484,7 @@ exponent(char *p0, int exp, int fmtch)
 
 #if !defined(HAVE_VSNPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
 int
-sudo_vsnprintf(char *str, size_t n, const char *fmt, va_list ap)
+sudo_vsnprintf(char * restrict str, size_t n, const char * restrict fmt, va_list ap)
 {
 	if (n > INT_MAX) {
 		errno = EOVERFLOW;
@@ -1497,7 +1497,7 @@ sudo_vsnprintf(char *str, size_t n, const char *fmt, va_list ap)
 
 #if !defined(HAVE_SNPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
 int
-sudo_snprintf(char *str, size_t n, char const *fmt, ...)
+sudo_snprintf(char * restrict str, size_t n, char const * restrict fmt, ...)
 {
 	int ret;
 	va_list ap;
@@ -1516,7 +1516,7 @@ sudo_snprintf(char *str, size_t n, char const *fmt, ...)
 
 #if !defined(HAVE_VASPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
 int
-sudo_vasprintf(char **str, const char *fmt, va_list ap)
+sudo_vasprintf(char ** restrict str, const char * restrict fmt, va_list ap)
 {
 	int ret;
 
@@ -1529,7 +1529,7 @@ sudo_vasprintf(char **str, const char *fmt, va_list ap)
 
 #if !defined(HAVE_ASPRINTF) || defined(PREFER_PORTABLE_SNPRINTF)
 int
-sudo_asprintf(char **str, char const *fmt, ...)
+sudo_asprintf(char ** restrict str, char const * restrict fmt, ...)
 {
 	int ret;
 	va_list ap;

--- a/lib/util/strlcat.c
+++ b/lib/util/strlcat.c
@@ -40,7 +40,7 @@
  * If retval >= dsize, truncation occurred.
  */
 size_t
-sudo_strlcat(char *dst, const char *src, size_t dsize)
+sudo_strlcat(char * restrict dst, const char * restrict src, size_t dsize)
 {
 	const char *odst = dst;
 	const char *osrc = src;

--- a/lib/util/strlcpy.c
+++ b/lib/util/strlcpy.c
@@ -38,7 +38,7 @@
  * Returns strlen(src); if retval >= dsize, truncation occurred.
  */
 size_t
-sudo_strlcpy(char *dst, const char *src, size_t dsize)
+sudo_strlcpy(char * restrict dst, const char * restrict src, size_t dsize)
 {
 	const char *osrc = src;
 	size_t nleft = dsize;

--- a/lib/util/sudo_debug.c
+++ b/lib/util/sudo_debug.c
@@ -741,7 +741,7 @@ out:
 
 void
 sudo_debug_vprintf2_v1(const char *func, const char *file, int lineno,
-    unsigned int level, const char *fmt, va_list ap)
+    unsigned int level, const char * restrict fmt, va_list ap)
 {
     int pri, saved_errno = errno;
     unsigned int subsys;
@@ -818,7 +818,7 @@ out:
 
 #ifdef NO_VARIADIC_MACROS
 void
-sudo_debug_printf_nvm_v1(int pri, const char *fmt, ...)
+sudo_debug_printf_nvm_v1(int pri, const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -830,7 +830,7 @@ sudo_debug_printf_nvm_v1(int pri, const char *fmt, ...)
 
 void
 sudo_debug_printf2_v1(const char *func, const char *file, int lineno,
-    unsigned int level, const char *fmt, ...)
+    unsigned int level, const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -1149,20 +1149,20 @@ sudo_debug_needed_v1(unsigned int level)
 
 void
 sudo_debug_vprintf2_v1(const char *func, const char *file, int lineno,
-    unsigned int level, const char *fmt, va_list ap)
+    unsigned int level, const char * restrict fmt, va_list ap)
 {
 }
 
 #ifdef NO_VARIADIC_MACROS
 void
-sudo_debug_printf_nvm_v1(int pri, const char *fmt, ...)
+sudo_debug_printf_nvm_v1(int pri, const char * restrict fmt, ...)
 {
 }
 #endif /* NO_VARIADIC_MACROS */
 
 void
 sudo_debug_printf2_v1(const char *func, const char *file, int lineno,
-    unsigned int level, const char *fmt, ...)
+    unsigned int level, const char * restrict fmt, ...)
 {
 }
 

--- a/lib/util/ttyname_dev.c
+++ b/lib/util/ttyname_dev.c
@@ -223,7 +223,7 @@ done:
 }
 
 static char *
-sudo_dev_check(dev_t rdev, const char *devname, char *buf, size_t buflen)
+sudo_dev_check(dev_t rdev, const char * restrict devname, char * restrict buf, size_t buflen)
 {
     struct stat sb;
     debug_decl(sudo_dev_check, SUDO_DEBUG_UTIL);

--- a/logsrvd/iolog_writer.c
+++ b/logsrvd/iolog_writer.c
@@ -421,7 +421,7 @@ fill_seq(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_user(char *str, size_t strsize, void *v)
+fill_user(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;
@@ -435,7 +435,7 @@ fill_user(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_group(char *str, size_t strsize, void *v)
+fill_group(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;
@@ -449,7 +449,7 @@ fill_group(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_runas_user(char *str, size_t strsize, void *v)
+fill_runas_user(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;
@@ -463,7 +463,7 @@ fill_runas_user(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_runas_group(char *str, size_t strsize, void *v)
+fill_runas_group(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;
@@ -478,7 +478,7 @@ fill_runas_group(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_hostname(char *str, size_t strsize, void *v)
+fill_hostname(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;
@@ -492,7 +492,7 @@ fill_hostname(char *str, size_t strsize, void *v)
 }
 
 static size_t
-fill_command(char *str, size_t strsize, void *v)
+fill_command(char * restrict str, size_t strsize, void * restrict v)
 {
     struct iolog_path_closure *closure = v;
     const struct eventlog *evlog = closure->evlog;

--- a/logsrvd/logsrvd_journal.c
+++ b/logsrvd/logsrvd_journal.c
@@ -455,7 +455,7 @@ journal_restart(RestartMessage *msg, uint8_t *buf, size_t buflen,
 }
 
 static bool
-journal_write(uint8_t *buf, size_t len, struct connection_closure *closure)
+journal_write(uint8_t * restrict buf, size_t len, struct connection_closure * restrict closure)
 {
     uint32_t msg_len;
     debug_decl(journal_write, SUDO_DEBUG_UTIL);
@@ -512,8 +512,8 @@ journal_accept(AcceptMessage *msg, uint8_t *buf, size_t len,
  * Store a RejectMessage from the client in the journal.
  */
 static bool
-journal_reject(RejectMessage *msg, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_reject(RejectMessage *msg, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_reject, SUDO_DEBUG_UTIL);
 
@@ -532,8 +532,8 @@ journal_reject(RejectMessage *msg, uint8_t *buf, size_t len,
  * Store an ExitMessage from the client in the journal.
  */
 static bool
-journal_exit(ExitMessage *msg, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_exit(ExitMessage *msg, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_exit, SUDO_DEBUG_UTIL);
 
@@ -550,8 +550,8 @@ journal_exit(ExitMessage *msg, uint8_t *buf, size_t len,
  * Store an AlertMessage from the client in the journal.
  */
 static bool
-journal_alert(AlertMessage *msg, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_alert(AlertMessage *msg, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_alert, SUDO_DEBUG_UTIL);
 
@@ -570,8 +570,8 @@ journal_alert(AlertMessage *msg, uint8_t *buf, size_t len,
  * Store an IoBuffer from the client in the journal.
  */
 static bool
-journal_iobuf(int iofd, IoBuffer *iobuf, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_iobuf(int iofd, IoBuffer *iobuf, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_iobuf, SUDO_DEBUG_UTIL);
 
@@ -586,8 +586,8 @@ journal_iobuf(int iofd, IoBuffer *iobuf, uint8_t *buf, size_t len,
  * Store a CommandSuspend message from the client in the journal.
  */
 static bool
-journal_suspend(CommandSuspend *msg, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_suspend(CommandSuspend *msg, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_suspend, SUDO_DEBUG_UTIL);
 
@@ -600,8 +600,8 @@ journal_suspend(CommandSuspend *msg, uint8_t *buf, size_t len,
  * Store a ChangeWindowSize message from the client in the journal.
  */
 static bool
-journal_winsize(ChangeWindowSize *msg, uint8_t *buf, size_t len,
-    struct connection_closure *closure)
+journal_winsize(ChangeWindowSize *msg, uint8_t * restrict buf, size_t len,
+    struct connection_closure * restrict closure)
 {
     debug_decl(journal_winsize, SUDO_DEBUG_UTIL);
 

--- a/plugins/audit_json/audit_json.c
+++ b/plugins/audit_json/audit_json.c
@@ -380,7 +380,7 @@ add_timestamp(struct json_container *jsonc, struct timespec *ts)
 }
 
 static int
-audit_write_json(struct json_container *jsonc)
+audit_write_json(struct json_container * restrict jsonc)
 {
     struct stat sb;
     int ret = -1;

--- a/plugins/group_file/plugin_test.c
+++ b/plugins/group_file/plugin_test.c
@@ -45,7 +45,7 @@ static void *group_handle;
 static struct sudoers_group_plugin *group_plugin;
 
 static int
-plugin_printf(int msg_type, const char *fmt, ...)
+plugin_printf(int msg_type, const char * restrict fmt, ...)
 {
     va_list ap;
     FILE *fp;

--- a/plugins/python/pyhelpers.c
+++ b/plugins/python/pyhelpers.c
@@ -28,7 +28,7 @@
 #include "pathnames.h"
 
 static int
-_sudo_printf_default(int msg_type, const char *fmt, ...)
+_sudo_printf_default(int msg_type, const char * restrict fmt, ...)
 {
     FILE *fp = stdout;
     FILE *ttyfp = NULL;

--- a/plugins/python/regress/iohelpers.c
+++ b/plugins/python/regress/iohelpers.c
@@ -96,7 +96,7 @@ cleanup:
 }
 
 int
-vsnprintf_append(char *output, size_t max_output_len, const char *fmt, va_list args)
+vsnprintf_append(char * restrict output, size_t max_output_len, const char * restrict fmt, va_list args)
 {
     va_list args2;
     va_copy(args2, args);
@@ -109,7 +109,7 @@ vsnprintf_append(char *output, size_t max_output_len, const char *fmt, va_list a
 }
 
 int
-snprintf_append(char *output, size_t max_output_len, const char *fmt, ...)
+snprintf_append(char * restrict output, size_t max_output_len, const char * restrict fmt, ...)
 {
     va_list args;
     va_start(args, fmt);

--- a/plugins/python/regress/iohelpers.h
+++ b/plugins/python/regress/iohelpers.h
@@ -49,8 +49,8 @@ char *str_replaced(const char *string, size_t dest_length, const char *old, cons
 // same, but "string" must be able to store 'max_length' number of characters including the null terminator
 void str_replace_in_place(char *string, size_t max_length, const char *old, const char *new);
 
-int vsnprintf_append(char *output, size_t max_output_len, const char *fmt, va_list args);
-int snprintf_append(char *output, size_t max_output_len, const char *fmt, ...);
+int vsnprintf_append(char * restrict output, size_t max_output_len, const char * restrict fmt, va_list args);
+int snprintf_append(char * restrict output, size_t max_output_len, const char * restrict fmt, ...);
 
 int str_array_count(char **str_array);
 void str_array_snprint(char *out_str, size_t max_len, char **str_array, int array_len);

--- a/plugins/python/regress/testhelpers.c
+++ b/plugins/python/regress/testhelpers.c
@@ -193,7 +193,7 @@ fake_conversation_with_suspend(int num_msgs, const struct sudo_conv_message msgs
 }
 
 int
-fake_printf(int msg_type, const char *fmt, ...)
+fake_printf(int msg_type, const char * restrict fmt, ...)
 {
     int rc = -1;
     va_list args;

--- a/plugins/python/regress/testhelpers.h
+++ b/plugins/python/regress/testhelpers.h
@@ -154,7 +154,7 @@ int fake_conversation(int num_msgs, const struct sudo_conv_message msgs[],
 int fake_conversation_with_suspend(int num_msgs, const struct sudo_conv_message msgs[],
                                    struct sudo_conv_reply replies[], struct sudo_conv_callback *callback);
 
-int fake_printf(int msg_type, const char *fmt, ...);
+int fake_printf(int msg_type, const char * restrict fmt, ...);
 
 int verify_log_lines(const char *reference_path);
 

--- a/plugins/sudoers/audit.c
+++ b/plugins/sudoers/audit.c
@@ -103,7 +103,7 @@ audit_failure_int(char *const argv[], const char *message)
 }
 
 int
-vaudit_failure(char *const argv[], char const *const fmt, va_list ap)
+vaudit_failure(char *const argv[], char const * restrict const fmt, va_list ap)
 {
     int oldlocale, ret;
     char *message;
@@ -129,7 +129,7 @@ vaudit_failure(char *const argv[], char const *const fmt, va_list ap)
 }
 
 int
-audit_failure(char *const argv[], char const *const fmt, ...)
+audit_failure(char *const argv[], char const * restrict const fmt, ...)
 {
     va_list ap;
     int ret;

--- a/plugins/sudoers/check_aliases.c
+++ b/plugins/sudoers/check_aliases.c
@@ -38,7 +38,7 @@ struct alias_warned {
 };
 SLIST_HEAD(alias_warned_list, alias_warned);
 
-static bool alias_warnx(const char *file, int line, int column, bool strict, bool quiet, const char *fmt, ...) sudo_printflike(6, 7);
+static bool alias_warnx(const char *file, int line, int column, bool strict, bool quiet, const char * restrict fmt, ...) sudo_printflike(6, 7);
 
 static bool
 alias_warned(struct alias_warned_list *warned, char *name)
@@ -71,7 +71,7 @@ alias_warned_add(struct alias_warned_list *warned, char *name)
 
 static bool
 alias_warnx(const char *file, int line, int column, bool strict, bool quiet,
-    const char *fmt, ...)
+    const char * restrict fmt, ...)
 {
     bool ret = true;
     va_list ap;

--- a/plugins/sudoers/cvtsudoers.c
+++ b/plugins/sudoers/cvtsudoers.c
@@ -468,7 +468,7 @@ done:
 }
 
 void
-log_warnx(const char *fmt, ...)
+log_warnx(const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -1082,7 +1082,7 @@ print_aliases_sudoers(struct sudoers_parse_tree *parse_tree,
 static FILE *output_fp;		/* global for convert_sudoers_output */
 
 static int
-convert_sudoers_output(const char *buf)
+convert_sudoers_output(const char * restrict buf)
 {
     return fputs(buf, output_fp);
 }

--- a/plugins/sudoers/cvtsudoers.h
+++ b/plugins/sudoers/cvtsudoers.h
@@ -87,7 +87,7 @@ struct cvtsudoers_filter {
 
 /* cvtsudoers.c */
 extern struct cvtsudoers_filter *filters;
-void log_warnx(const char *fmt, ...) sudo_printflike(1, 2);
+void log_warnx(const char * restrict fmt, ...) sudo_printflike(1, 2);
 
 /* cvtsudoers_csv.c */
 bool convert_sudoers_csv(const struct sudoers_parse_tree *parse_tree, const char *output_file, struct cvtsudoers_config *conf);

--- a/plugins/sudoers/cvtsudoers_csv.c
+++ b/plugins/sudoers/cvtsudoers_csv.c
@@ -112,7 +112,7 @@ defaults_to_alias_type(int defaults_type)
  * XXX - rewrite this
  */
 static bool
-print_csv_string(FILE *fp, const char *str, bool quoted)
+print_csv_string(FILE * restrict fp, const char * restrict str, bool quoted)
 {
     const char *src = str;
     char *dst, *newstr;

--- a/plugins/sudoers/defaults.c
+++ b/plugins/sudoers/defaults.c
@@ -73,7 +73,7 @@ static bool store_timespec(const char *str, struct sudo_defs_types *def);
 static bool store_rlimit(const char *str, struct sudo_defs_types *def);
 static bool list_op(const char *str, size_t, struct list_members *list, enum list_ops op);
 static bool valid_path(struct sudo_defs_types *def, const char *val, const char *file, int line, int column, bool quiet);
-static bool defaults_warnx(const char *file, int line, int column, bool quiet, const char *fmt, ...) sudo_printflike(5, 6);
+static bool defaults_warnx(const char *file, int line, int column, bool quiet, const char * restrict fmt, ...) sudo_printflike(5, 6);
 
 /*
  * Table describing compile-time and run-time options.
@@ -1249,7 +1249,7 @@ cb_passprompt_regex(const char *file, int line, int column,
 
 static bool
 defaults_warnx(const char *file, int line, int column, bool quiet,
-    const char *fmt, ...)
+    const char * restrict fmt, ...)
 {
     bool ret = true;
     va_list ap;

--- a/plugins/sudoers/gram.c
+++ b/plugins/sudoers/gram.c
@@ -3404,7 +3404,7 @@ yyreturnlab:
 
 /* Like yyerror() but takes a printf-style format string. */
 void
-sudoerserrorf(const char *fmt, ...)
+sudoerserrorf(const char * restrict fmt, ...)
 {
     const int column = (int)(sudolinebuf.toke_start + 1);
     va_list ap;

--- a/plugins/sudoers/gram.y
+++ b/plugins/sudoers/gram.y
@@ -1221,7 +1221,7 @@ group		:	ALIAS {
 %%
 /* Like yyerror() but takes a printf-style format string. */
 void
-sudoerserrorf(const char *fmt, ...)
+sudoerserrorf(const char * restrict fmt, ...)
 {
     const int column = (int)(sudolinebuf.toke_start + 1);
     va_list ap;

--- a/plugins/sudoers/ldap_util.c
+++ b/plugins/sudoers/ldap_util.c
@@ -661,7 +661,7 @@ sudo_ldap_value_len(const char *value)
  * Like strlcat() but escapes characters as per RFC 4515.
  */
 size_t
-sudo_ldap_value_cat(char *dst, const char *src, size_t size)
+sudo_ldap_value_cat(char * restrict dst, const char * restrict src, size_t size)
 {
     char *d = dst;
     const char *s = src;

--- a/plugins/sudoers/logging.c
+++ b/plugins/sudoers/logging.c
@@ -659,7 +659,7 @@ journal_parse_error(char *message)
  * Perform logging for log_warning()/log_warningx().
  */
 static bool
-vlog_warning(int flags, int errnum, const char *fmt, va_list ap)
+vlog_warning(int flags, int errnum, const char * restrict fmt, va_list ap)
 {
     struct eventlog evlog;
     struct timespec now;
@@ -766,7 +766,7 @@ done:
 }
 
 bool
-log_warning(int flags, const char *fmt, ...)
+log_warning(int flags, const char * restrict fmt, ...)
 {
     va_list ap;
     bool ret;
@@ -781,7 +781,7 @@ log_warning(int flags, const char *fmt, ...)
 }
 
 bool
-log_warningx(int flags, const char *fmt, ...)
+log_warningx(int flags, const char * restrict fmt, ...)
 {
     va_list ap;
     bool ret;
@@ -796,7 +796,7 @@ log_warningx(int flags, const char *fmt, ...)
 }
 
 bool
-gai_log_warning(int flags, int errnum, const char *fmt, ...)
+gai_log_warning(int flags, int errnum, const char * restrict fmt, ...)
 {
     va_list ap;
     bool ret;
@@ -871,7 +871,7 @@ done:
  * Does not write the message to stderr.
  */
 bool
-log_parse_error(const char *file, int line, int column, const char *fmt,
+log_parse_error(const char *file, int line, int column, const char * restrict fmt,
     va_list args)
 {
     const int flags = SLOG_RAW_MSG|SLOG_NO_STDERR;

--- a/plugins/sudoers/logging.h
+++ b/plugins/sudoers/logging.h
@@ -58,7 +58,7 @@ struct log_details {
 #define SLOG_AUDIT		0x40	/* send message to audit as well */
 #define SLOG_PARSE_ERROR	0x80	/* format as a parse error */
 
-typedef bool (*sudoers_logger_t)(const char *file, int line, int column, const char *fmt, va_list args);
+typedef bool (*sudoers_logger_t)(const char *file, int line, int column, const char * restrict fmt, va_list args);
 
 /* XXX - needed for auditing */
 extern int NewArgc;
@@ -73,8 +73,8 @@ struct log_details;
 bool sudoers_warn_setlocale(bool restore, int *cookie);
 bool sudoers_setlocale(int locale_type, int *prev_locale);
 int sudoers_getlocale(void);
-int audit_failure(char *const argv[], char const *const fmt, ...) sudo_printflike(2, 3);
-int vaudit_failure(char *const argv[], char const *const fmt, va_list ap) sudo_printflike(2, 0);
+int audit_failure(char *const argv[], char const * restrict const fmt, ...) sudo_printflike(2, 3);
+int vaudit_failure(char *const argv[], char const * restrict const fmt, va_list ap) sudo_printflike(2, 0);
 bool log_allowed(struct eventlog *evlog);
 bool log_exit_status(int exit_status);
 bool log_auth_failure(int status, unsigned int tries);
@@ -82,15 +82,15 @@ bool log_denial(int status, bool inform_user);
 bool log_failure(int status, int flags);
 bool log_server_alert(struct eventlog *evlog, struct timespec *now, const char *message, const char *errstr);
 bool log_server_reject(struct eventlog *evlog, const char *message);
-bool log_warning(int flags, const char *fmt, ...) sudo_printflike(2, 3);
-bool log_warningx(int flags, const char *fmt, ...) sudo_printflike(2, 3);
-bool gai_log_warning(int flags, int errnum, const char *fmt, ...) sudo_printflike(3, 4);
+bool log_warning(int flags, const char * restrict fmt, ...) sudo_printflike(2, 3);
+bool log_warningx(int flags, const char * restrict fmt, ...) sudo_printflike(2, 3);
+bool gai_log_warning(int flags, int errnum, const char * restrict fmt, ...) sudo_printflike(3, 4);
 bool sudoers_initlocale(const char *ulocale, const char *slocale);
 bool sudoers_locale_callback(const char *file, int line, int column, const union sudo_defs_val *sd_un, int op);
 void sudoers_to_eventlog(struct eventlog *evlog, const char *cmnd, char * const argv[], char *const envp[], const char *uuid_str);
 void init_eventlog_config(void);
 bool init_log_details(struct log_details *details, struct eventlog *evlog);
-bool log_parse_error(const char *file, int line, int column, const char *fmt, va_list ap) sudo_printf0like(4, 0);
+bool log_parse_error(const char *file, int line, int column, const char * restrict fmt, va_list ap) sudo_printf0like(4, 0);
 bool mail_parse_errors(void);
 
 #endif /* SUDOERS_LOGGING_H */

--- a/plugins/sudoers/parse.h
+++ b/plugins/sudoers/parse.h
@@ -404,7 +404,7 @@ int check_aliases(struct sudoers_parse_tree *parse_tree, bool strict, bool quiet
 /* gram.y */
 extern bool parse_error;
 extern struct sudoers_parse_tree parsed_policy;
-extern bool (*sudoers_error_hook)(const char *file, int line, int column, const char *fmt, va_list args);
+extern bool (*sudoers_error_hook)(const char *file, int line, int column, const char * restrict fmt, va_list args);
 bool reset_parser(void);
 void free_member(struct member *m);
 void free_members(struct member_list *members);

--- a/plugins/sudoers/regress/fuzz/fuzz_policy.c
+++ b/plugins/sudoers/regress/fuzz/fuzz_policy.c
@@ -161,7 +161,7 @@ fuzz_conversation(int num_msgs, const struct sudo_conv_message msgs[],
 }
 
 static int
-fuzz_printf(int msg_type, const char *fmt, ...)
+fuzz_printf(int msg_type, const char * restrict fmt, ...)
 {
     return 0;
 }
@@ -742,21 +742,21 @@ group_plugin_unload(void)
 
 /* STUB */
 bool
-log_warning(int flags, const char *fmt, ...)
+log_warning(int flags, const char * restrict fmt, ...)
 {
     return true;
 }
 
 /* STUB */
 bool
-log_warningx(int flags, const char *fmt, ...)
+log_warningx(int flags, const char * restrict fmt, ...)
 {
     return true;
 }
 
 /* STUB */
 bool
-gai_log_warning(int flags, int errnum, const char *fmt, ...)
+gai_log_warning(int flags, int errnum, const char * restrict fmt, ...)
 {
     return true;
 }
@@ -791,7 +791,7 @@ mail_parse_errors(void)
 
 /* STUB */
 bool
-log_parse_error(const char *file, int line, int column, const char *fmt,
+log_parse_error(const char *file, int line, int column, const char * restrict fmt,
     va_list args)
 {
     return true;
@@ -799,7 +799,7 @@ log_parse_error(const char *file, int line, int column, const char *fmt,
 
 /* STUB */
 int
-audit_failure(char *const argv[], char const *const fmt, ...)
+audit_failure(char *const argv[], char const * restrict const fmt, ...)
 {
     return 0;
 }

--- a/plugins/sudoers/regress/fuzz/fuzz_sudoers.c
+++ b/plugins/sudoers/regress/fuzz/fuzz_sudoers.c
@@ -42,7 +42,7 @@
 #include "interfaces.h"
 
 static int fuzz_conversation(int num_msgs, const struct sudo_conv_message msgs[], struct sudo_conv_reply replies[], struct sudo_conv_callback *callback);
-static int fuzz_printf(int msg_type, const char *fmt, ...);
+static int fuzz_printf(int msg_type, const char * restrict fmt, ...);
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 /* For set_cmnd_path() */
@@ -67,7 +67,7 @@ open_sudoers(const char *file, char **outfile, bool doedit, bool *keepopen)
 }
 
 static int
-fuzz_printf(int msg_type, const char *fmt, ...)
+fuzz_printf(int msg_type, const char * restrict fmt, ...)
 {
     return 0;
 }
@@ -125,7 +125,7 @@ mail_parse_errors(void)
 
 /* STUB */
 bool
-log_warningx(int flags, const char *fmt, ...)
+log_warningx(int flags, const char * restrict fmt, ...)
 {
     return true;
 }

--- a/plugins/sudoers/regress/fuzz/fuzz_sudoers_ldif.c
+++ b/plugins/sudoers/regress/fuzz/fuzz_sudoers_ldif.c
@@ -28,7 +28,7 @@
 
 #include "sudoers.h"
 
-static int fuzz_printf(int msg_type, const char *fmt, ...);
+static int fuzz_printf(int msg_type, const char * restrict fmt, ...);
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 /* Required to link with parser. */
@@ -48,7 +48,7 @@ open_sudoers(const char *file, char **outfile, bool doedit, bool *keepopen)
 }
 
 static int
-fuzz_printf(int msg_type, const char *fmt, ...)
+fuzz_printf(int msg_type, const char * restrict fmt, ...)
 {
     return 0;
 }

--- a/plugins/sudoers/regress/iolog_plugin/check_iolog_plugin.c
+++ b/plugins/sudoers/regress/iolog_plugin/check_iolog_plugin.c
@@ -52,7 +52,7 @@ usage(void)
 }
 
 static int
-sudo_printf_int(int msg_type, const char *fmt, ...)
+sudo_printf_int(int msg_type, const char * restrict fmt, ...)
 {
     va_list ap;
     int len;
@@ -408,7 +408,7 @@ restore_perms(void)
 }
 
 bool
-log_warning(int flags, const char *fmt, ...)
+log_warning(int flags, const char * restrict fmt, ...)
 {
     va_list ap;
 
@@ -420,7 +420,7 @@ log_warning(int flags, const char *fmt, ...)
 }
 
 bool
-log_warningx(int flags, const char *fmt, ...)
+log_warningx(int flags, const char * restrict fmt, ...)
 {
     va_list ap;
 

--- a/plugins/sudoers/sudo_ldap.h
+++ b/plugins/sudoers/sudo_ldap.h
@@ -100,7 +100,7 @@ int sudo_ldap_innetgr_int(void *v, const char *netgr, const char *host, const ch
 /* ldap_util.c */
 bool sudo_ldap_is_negated(char **valp);
 size_t sudo_ldap_value_len(const char *value);
-size_t sudo_ldap_value_cat(char *dst, const char *src, size_t size);
+size_t sudo_ldap_value_cat(char * restrict dst, const char * restrict src, size_t size);
 char *sudo_ldap_value_dup(const char *src);
 int sudo_ldap_parse_option(char *optstr, char **varp, char **valp);
 struct privilege *sudo_ldap_role_to_priv(const char *cn, void *hosts, void *runasusers, void *runasgroups, void *cmnds, void *opts, const char *notbefore, const char *notafter, bool warnings, bool store_options, sudo_ldap_iter_t iter);

--- a/plugins/sudoers/sudo_printf.c
+++ b/plugins/sudoers/sudo_printf.c
@@ -33,7 +33,7 @@
 #include "pathnames.h"
 
 static int
-sudo_printf_int(int msg_type, const char *fmt, ...)
+sudo_printf_int(int msg_type, const char * restrict fmt, ...)
 {
     FILE *fp = stdout;
     FILE *ttyfp = NULL;

--- a/plugins/sudoers/testsudoers.c
+++ b/plugins/sudoers/testsudoers.c
@@ -71,8 +71,8 @@ static void dump_sudoers(void);
 static void set_runaspw(const char *);
 static void set_runasgr(const char *);
 static bool cb_runas_default(const char *file, int line, int column, const union sudo_defs_val *, int);
-static int testsudoers_error(const char *msg);
-static int testsudoers_output(const char *buf);
+static int testsudoers_error(const char * restrict buf);
+static int testsudoers_output(const char * restrict buf);
 sudo_noreturn static void usage(void);
 static void cb_userspec(struct userspec *us, int user_match);
 static void cb_privilege(struct privilege *priv, int host_match);
@@ -715,13 +715,13 @@ done:
 }
 
 static int
-testsudoers_output(const char *buf)
+testsudoers_output(const char * restrict buf)
 {
     return fputs(buf, stdout);
 }
 
 static int
-testsudoers_error(const char *buf)
+testsudoers_error(const char *restrict buf)
 {
     return fputs(buf, stderr);
 }

--- a/plugins/sudoers/visudo.c
+++ b/plugins/sudoers/visudo.c
@@ -91,7 +91,7 @@ static char *get_editor(int *editor_argc, char ***editor_argv);
 static bool check_syntax(const char *, bool, bool, bool, bool);
 static bool edit_sudoers(struct sudoersfile *, char *, int, char **, int);
 static bool install_sudoers(struct sudoersfile *, bool, bool);
-static bool visudo_track_error(const char *file, int line, int column, const char *fmt, va_list args) sudo_printf0like(4, 0);
+static bool visudo_track_error(const char *file, int line, int column, const char * restrict fmt, va_list args) sudo_printf0like(4, 0);
 static int print_unused(struct sudoers_parse_tree *, struct alias *, void *);
 static bool reparse_sudoers(char *, int, char **, bool, bool);
 static int run_command(const char *, char *const *);
@@ -343,7 +343,7 @@ done:
 }
 
 static bool
-visudo_track_error(const char *file, int line, int column, const char *fmt,
+visudo_track_error(const char *file, int line, int column, const char * restrict fmt,
      va_list args)
 {
     struct sudoersfile *sp;

--- a/src/conversation.c
+++ b/src/conversation.c
@@ -155,7 +155,7 @@ sudo_conversation_1_7(int num_msgs, const struct sudo_conv_message msgs[],
 }
 
 int
-sudo_conversation_printf(int msg_type, const char *fmt, ...)
+sudo_conversation_printf(int msg_type, const char * restrict fmt, ...)
 {
     const char *crnl = NULL;
     FILE *ttyfp = NULL;

--- a/src/exec_preload.c
+++ b/src/exec_preload.c
@@ -50,7 +50,7 @@ sudo_allocarray(size_t nmemb, size_t size)
  * Currently only supports %%, %c, %d, and %s escapes.
  */
 static char *
-fmtstr(sudo_alloc_fn_t alloc_fn, sudo_free_fn_t free_fn, const char *ofmt, ...)
+fmtstr(sudo_alloc_fn_t alloc_fn, sudo_free_fn_t free_fn, const char * restrict ofmt, ...)
 {
     char *cp, *cur, *newstr = NULL;
     size_t len, size = 1;

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -760,7 +760,7 @@ usage_excl_ticket(void)
 }
 
 static int
-help_out(const char *buf)
+help_out(const char * restrict buf)
 {
     return fputs(buf, stdout);
 }

--- a/src/sudo_plugin_int.h
+++ b/src/sudo_plugin_int.h
@@ -126,7 +126,7 @@ int sudo_conversation(int num_msgs, const struct sudo_conv_message msgs[],
     struct sudo_conv_reply replies[], struct sudo_conv_callback *callback);
 int sudo_conversation_1_7(int num_msgs, const struct sudo_conv_message msgs[],
     struct sudo_conv_reply replies[]);
-int sudo_conversation_printf(int msg_type, const char *fmt, ...);
+int sudo_conversation_printf(int msg_type, const char * restrict fmt, ...);
 
 bool sudo_load_plugins(void);
 


### PR DESCRIPTION
The format value has to be a string literal, every time.

Otherwise, you are not using these functions correctly. To reinforce this fact, I putrestrict over every non-contrib example of this I could find.