### PR TITLE
Write to dst only if sudo_ldap_value_cat succeeds

### DIFF
--- a/plugins/sudoers/ldap_util.c
+++ b/plugins/sudoers/ldap_util.c
@@ -740,11 +740,11 @@ sudo_ldap_value_dup(const char *src)
     if (dst == NULL)
 	return NULL;
 
-    *dst = '\0';
     if (sudo_ldap_value_cat(dst, src, size) >= size) {
 	/* Should not be possible... */
 	free(dst);
-	dst = NULL;
+	return NULL;
     }
+    *dst = '\0';
     return dst;
 }


### PR DESCRIPTION
There's no point in writing to memory if it has to be freed anyway.