### PR TITLE
Use U, not UL, for 32-bit platforms

### DIFF
--- a/lib/util/roundup.c
+++ b/lib/util/roundup.c
@@ -64,7 +64,7 @@ sudo_pow2_roundup_v2(size_t len)
 #if defined(__LP64__) && defined(HAVE___BUILTIN_CLZL)
     return 1UL << (64 - __builtin_clzl(len - 1));
 #elif !defined(__LP64__) && defined(HAVE___BUILTIN_CLZ)
-    return 1UL << (32 - __builtin_clz(len - 1));
+    return 1U << (32 - __builtin_clz(len - 1));
 #else
     len--;
     len |= len >> 1;


### PR DESCRIPTION
size_t is an unsigned int on 32-bit platforms, not an unsigned long.