### PR TITLE
Add Orbiton to the list of editors that supports "+lineno"

### DIFF
--- a/plugins/sudoers/visudo.c
+++ b/plugins/sudoers/visudo.c
@@ -432,6 +432,7 @@ static const char *lineno_editors[] = {
     "nex",
     "nvi",
     "nvim",
+    "o",
     "pico",
     "vi",
     "vile",

--- a/plugins/sudoers/visudo.c
+++ b/plugins/sudoers/visudo.c
@@ -421,21 +421,21 @@ get_editor(int *editor_argc, char ***editor_argv)
  * No other wild cards are supported.
  */
 static const char *lineno_editors[] = {
-    "ex",
-    "nex",
-    "vi",
-    "nvi",
-    "vim",
-    "nvim",
-    "elvis",
     "*macs",
-    "mg",
-    "vile",
-    "jove",
-    "pico",
-    "nano",
     "ee",
+    "elvis",
+    "ex",
     "joe",
+    "jove",
+    "mg",
+    "nano",
+    "nex",
+    "nvi",
+    "nvim",
+    "pico",
+    "vi",
+    "vile",
+    "vim",
     "zile",
     NULL
 };


### PR DESCRIPTION
Orbiton is an editor that is packaged for these systems:


| As **orbiton**                                                                                                                    | As **o-editor**                                                                                                                     |
|--------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
| [![Packaging status](https://repology.org/badge/vertical-allrepos/orbiton.svg)](https://repology.org/project/orbiton/versions) | [![Packaging status](https://repology.org/badge/vertical-allrepos/o-editor.svg)](https://repology.org/project/o-editor/versions) |

Once installed, Orbiton is available as `/usr/bin/o` or `/usr/local/bin/o`.

This pull request contains one commit that sorts the list of editors that supports "+lineno" alphabetically, and one commit that adds `o` to the list.