### PR TITLE
Bugfix - Correcting NETGROUP_QUERY toggle behaviour

### DIFF
--- a/plugins/sudoers/ldap_conf.c
+++ b/plugins/sudoers/ldap_conf.c
@@ -599,8 +599,6 @@ sudo_ldap_read_config(const struct sudoers_context *ctx)
 	    debug_return_bool(false);
 	}
     }
-    if (!STAILQ_EMPTY(&ldap_conf.netgroup_base))
-	ldap_conf.netgroup_query = false;
 
     DPRINTF1("LDAP Config Summary");
     DPRINTF1("===================");


### PR DESCRIPTION
When NETGROUP_BASE is defined the NETGROUP_QUERY toggle is no longer usable. Correcting this behaviour so regardless of NETGROUP_BASE being defined, users are still capable of toggling NETGROUP_QUERY, allowing a user to query netgroups directly, preserving the indended behaviour of this configuration option.

Unable to toggle netgroup_query when sudoers_base is set, breaking the intended behaviour called out by the man page
```
-bash-5.1# grep netgroup_query /etc/sudo-ldap.conf
netgroup_query on

```

```
sudo: ===================
sudo: uri              ldaps://ldap.example.com
sudo: ldap_version     3
sudo: sudoers_base     ou=SUDOers,dc=example,dc=com
sudo: search_filter    (objectClass=sudoRole)
sudo: netgroup_base    ou=netgroups,dc=example,dc=com
sudo: netgroup_query   (no)                                                                                <<<<<<<<<<<<
sudo: netgroup_search_filter (&(objectClass=nisNetgroup)(!(cn=*_users)))
sudo: binddn           (anonymous)
sudo: bindpw           (anonymous)
sudo: bind_timelimit   20
sudo: timelimit        30
sudo: ssl              (no)
sudo: tls_cacertdir    /etc/openldap/cacerts
sudo: ===================