### PR TITLE
lib/utils: detect failure to generate signals list and names

### DIFF
--- a/lib/util/Makefile.in
+++ b/lib/util/Makefile.in
@@ -272,11 +272,17 @@ $(srcdir)/sys_signame.h: $(srcdir)/siglist.in
 	    $(AWK) 'BEGIN {print "/* public domain */\n\n#include <config.h>\n#include <sys/types.h>\n#include <signal.h>\n#include \"sudo_compat.h\"\n\nint sudo_end_of_headers;\nstatic char *sudo_sys_signame[NSIG];\n"} /^    [A-Z]/ {printf("#ifdef SIG%s\n    if (sudo_sys_signame[SIG%s] == NULL)\n\tsudo_sys_signame[SIG%s] = \"%s\";\n#endif\n", $$1, $$1, $$1, $$1)}' < $(srcdir)/siglist.in > $@; \
 	fi
 
-mksiglist.h: $(srcdir)/sys_siglist.h
-	$(CPP) $(CPPFLAGS) $(srcdir)/sys_siglist.h | $(SED) -e '1,/^int sudo_end_of_headers;/d' -e '/^#/d' > mksiglist.h
+sys_siglist.i: $(srcdir)/sys_siglist.h
+	$(CPP) $(CPPFLAGS) $< > $@
 
-mksigname.h: $(srcdir)/sys_signame.h
-	$(CPP) $(CPPFLAGS) $(srcdir)/sys_signame.h | $(SED) -e '1,/^int sudo_end_of_headers;/d' -e '/^#/d' > mksigname.h
+sys_signame.i: $(srcdir)/sys_signame.h
+	$(CPP) $(CPPFLAGS) $< > $@
+
+mksiglist.h: sys_siglist.i
+	$(SED) -e '1,/^int sudo_end_of_headers;/d' -e '/^#/d' < $< > mksiglist.h
+
+mksigname.h: sys_signame.i
+	$(SED) -e '1,/^int sudo_end_of_headers;/d' -e '/^#/d' < $< > mksigname.h
 
 closefrom_test: $(CLOSEFROM_TEST_OBJS) libsudo_util.la
 	$(LIBTOOL) $(LTFLAGS) --mode=link $(CC) -o $@ $(CLOSEFROM_TEST_OBJS) libsudo_util.la $(ASAN_LDFLAGS) $(PIE_LDFLAGS) $(HARDENING_LDFLAGS) $(TEST_LDFLAGS) $(TEST_LIBS)


### PR DESCRIPTION
Currently, we generate the signal list and names by running cpp on our header, and piping the result into sed.

However, when cpp fails [0], we do not catch that failure, as the error code of the LHS of a pipe is lost, with the pipe returning the RHS-most return code.

Fix that by introducing two new intermediate rules, each to generate the preprocessed .i files, and use those as dependencies and input to the rule that generates the headers. Those two .i files will be cleaned up by the existing *.i glob.

[0] a failure happens on recent hosts, due to inconsistency with time64_t and large-file support (lines elided and wrapped for readability):

    /usr/bin/cpp [...] ./sys_signame.h \
    | /usr/bin/sed -e '1,/^int sudo_end_of_headers;/d' -e '/^#/d' > mksigname.h
    In file included from /usr/include/features.h:394,
                     from /usr/include/sys/types.h:25,
                     from ./sys_signame.h:4:
    /usr/include/features-time64.h:26:5: error: #error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
       26 | #   error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
          |     ^~~~~
    /usr/bin/gcc [...] ./mksigname.c -o mksigname
    In file included from /usr/include/features.h:394,
                     from /usr/include/bits/libc-header-start.h:33,
                     from /usr/include/stdlib.h:26,
                     from ./mksigname.c:27:
    /usr/include/features-time64.h:26:5: error: #error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
       26 | #   error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
          |     ^~~~~
    make[2]: *** [Makefile:263: mksigname] Error 1

In that case, we were lucky that the subsequent gcc call also failed, and for the same reason. That time64_t and lfs issue should be fixed (at least investigated), but that does not mean we should not be more robust when parsing the header either.