### PR TITLE
m4/openssl.m4: fix cross-compilation with wolfssl

### DIFF
--- a/m4/openssl.m4
+++ b/m4/openssl.m4
@@ -228,7 +228,7 @@ AC_DEFUN([SUDO_CHECK_OPENSSL], [
 		# So we find the openssl compat headers under wolfssl
 		AX_APPEND_FLAG([$f/wolfssl], [CPPFLAGS])
 	    done
-	    if test "$CPPFLAGS" = "$O_CPPFLAGS"; then
+	    if test "$cross_compiling" != "yes" -a "$CPPFLAGS" = "$O_CPPFLAGS"; then
 		# So we find the openssl compat headers under wolfssl (XXX)
 		AX_APPEND_FLAG([-I/usr/include/wolfssl], [CPPFLAGS])
 	    fi


### PR DESCRIPTION
Do not append `-I/usr/include/wolfssl` when cross-compiling