### PR TITLE
logsrvd,plugins/sudoers: add debug log on TLS verification error

### DIFF
--- a/logsrvd/tls_client.c
+++ b/logsrvd/tls_client.c
@@ -67,8 +67,18 @@ verify_peer_identity(int preverify_ok, X509_STORE_CTX *ctx)
     X509 *peer_cert;
     debug_decl(verify_peer_identity, SUDO_DEBUG_UTIL);
 
+    current_cert = X509_STORE_CTX_get_current_cert(ctx);
+
     /* if pre-verification of the cert failed, just propagate that result back */
     if (preverify_ok != 1) {
+        int err = X509_STORE_CTX_get_error(ctx);
+        char current_cert_name[256] = "";
+        if (current_cert != NULL)
+            X509_NAME_oneline(X509_get_subject_name(current_cert), current_cert_name, sizeof(current_cert_name));
+
+        sudo_debug_printf(SUDO_DEBUG_INFO|SUDO_DEBUG_LINENO,
+            "TLS verification failed for cert '%s': '%d:%s'", current_cert_name,
+            err, X509_verify_cert_error_string(err));
         debug_return_int(0);
     }
 
@@ -76,7 +86,6 @@ verify_peer_identity(int preverify_ok, X509_STORE_CTX *ctx)
      * Since this callback is called for each cert in the chain,
      * check that current cert is the peer's certificate
      */
-    current_cert = X509_STORE_CTX_get_current_cert(ctx);
     peer_cert = X509_STORE_CTX_get0_cert(ctx);
     if (current_cert != peer_cert) {
         debug_return_int(1);

--- a/plugins/sudoers/log_client.c
+++ b/plugins/sudoers/log_client.c
@@ -149,15 +149,24 @@ verify_peer_identity(int preverify_ok, X509_STORE_CTX *ctx)
     X509 *peer_cert;
     debug_decl(verify_peer_identity, SUDOERS_DEBUG_UTIL);
 
+    current_cert = X509_STORE_CTX_get_current_cert(ctx);
+
     /* if pre-verification of the cert failed, just propagate that result back */
     if (preverify_ok != 1) {
+        int err = X509_STORE_CTX_get_error(ctx);
+        char current_cert_name[256] = "";
+        if (current_cert != NULL)
+            X509_NAME_oneline(X509_get_subject_name(current_cert), current_cert_name, sizeof(current_cert_name));
+
+        sudo_debug_printf(SUDO_DEBUG_INFO|SUDO_DEBUG_LINENO,
+            "TLS verification failed for cert '%s': '%d:%s'", current_cert_name,
+            err, X509_verify_cert_error_string(err));
         debug_return_int(0);
     }
 
     /* since this callback is called for each cert in the chain,
      * check that current cert is the peer's certificate
      */
-    current_cert = X509_STORE_CTX_get_current_cert(ctx);
     peer_cert = X509_STORE_CTX_get0_cert(ctx);
 
     if (current_cert != peer_cert) {


### PR DESCRIPTION
I have accidentally generated wrong certificate for the sudo_logsrvd client for TLS communication (it was for a server and not a client), and felt it a bit hard to debug what the problem could be. Ended up adding these log messages, I think they could be useful.

Example message looks like this:

    May 15 12:13:15.611 sudo_logsrvd[23971] TLS verification failed for cert '/C=US/ST=Utah/O=sudo/OU=sudo Audit Server/CN=QPM': '26:unsupported certificate purpose' @ verify_peer_identity() ./logsrvd.c:1271