### PR TITLE
Restrict-qualify dst in base64_decode

### DIFF
--- a/plugins/sudoers/parse.h
+++ b/plugins/sudoers/parse.h
@@ -446,7 +446,7 @@ extern FILE *sudoersin;
 extern char *sudoers;
 
 /* base64.c */
-size_t base64_decode(const char * restrict str, unsigned char *dst, size_t dsize);
+size_t base64_decode(const char * restrict str, unsigned char * restrict dst, size_t dsize);
 size_t base64_encode(const unsigned char * restrict in, size_t in_len, char * restrict out, size_t out_len);
 
 /* timeout.c */


### PR DESCRIPTION
Definition restrict qualifies but not declaration in header.