### PR TITLE
Restrict-qualify sudo_hexchar_v1

### DIFF
--- a/include/sudo_util.h
+++ b/include/sudo_util.h
@@ -195,7 +195,7 @@ sudo_dso_public int sudo_getgrouplist2_v1(const char *name, gid_t basegid, GETGR
 #define sudo_getgrouplist2(_a, _b, _c, _d) sudo_getgrouplist2_v1((_a), (_b), (_c), (_d))
 
 /* hexchar.c */
-sudo_dso_public int sudo_hexchar_v1(const char *s);
+sudo_dso_public int sudo_hexchar_v1(const char s[restrict static 2]);
 #define sudo_hexchar(_a) sudo_hexchar_v1(_a)
 
 /* key_val.c */

--- a/lib/util/hexchar.c
+++ b/lib/util/hexchar.c
@@ -32,7 +32,7 @@
  * Returns a value 0-255 on success or -1 for invalid input.
  */
 int
-sudo_hexchar_v1(const char *s)
+sudo_hexchar_v1(const char s[restrict static 2])
 {
     unsigned char result[2];
     unsigned int i;


### PR DESCRIPTION
sudo_hexchar_v1 requires an array of at least size-2, and is not aliased.