### PR TITLE
Fix version typo for pam_silent option in sudoers man page

### DIFF
--- a/docs/sudoers.man.in
+++ b/docs/sudoers.man.in
@@ -3838,7 +3838,7 @@ This flag is
 \fIon\fR
 by default.
 .sp
-This setting is only supported by version 1.8.16 or higher.
+This setting is only supported by version 1.9.16 or higher.
 .TP 18n
 passprompt_override
 If set, the prompt specified by

--- a/docs/sudoers.mdoc.in
+++ b/docs/sudoers.mdoc.in
@@ -3637,7 +3637,7 @@ This flag is
 .Em on
 by default.
 .Pp
-This setting is only supported by version 1.8.16 or higher.
+This setting is only supported by version 1.9.16 or higher.
 .It passprompt_override
 If set, the prompt specified by
 .Em passprompt


### PR DESCRIPTION
The `sudoers(5)` man page entry for the `pam_silent` Defaults option incorrectly says that "This settings is only supported by version 1.**8**.16 or higher." (emphasis mine). This is incorrect, since the setting was added in 1.**9**.16.

This PR fixes this simple typo.