### PR TITLE
Add pam_silent setting to sudoers example config

### DIFF
--- a/plugins/sudoers/sudoers.in
+++ b/plugins/sudoers/sudoers.in
@@ -107,6 +107,10 @@ Defaults secure_path="@secure_path@"
 ## Some package scripts run a huge number of commands, which is made
 ## slower by these options and also can clutter up the logs.
 # Defaults!PKGMAN !intercept, !log_subcmds
+##
+## Uncomment to disable PAM silent mode.  Otherwise messages by PAM
+## modules such as pam_faillock will not be printed.
+# Defaults !pam_silent
 
 ##
 ## Runas alias specification


### PR DESCRIPTION
This PR adds a commented `Defaults !pam_silent` and an explanatory sentence to the default `sudoers` file.

Since it is possible that some users might be running into `pam_faillock` leading to inexplicably failing login attemps with no explanatory output (#216), making this option easily accessible could help these users fix their issue or rule out one problem more quickly without having to dig into the sudoers man page.