### PR TITLE
Allow --secure-path-value=no

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,7 @@ AC_SUBST([sssd_lib])
 AC_SUBST([nsswitch_conf])
 AC_SUBST([netsvc_conf])
 AC_SUBST([secure_path])
+AC_SUBST([secure_path_config])
 AC_SUBST([secure_path_status])
 AC_SUBST([editor])
 AC_SUBST([pam_session])
@@ -230,6 +231,7 @@ sesh_file="$libexecdir/sudo/sesh"
 visudo="$sbindir/visudo"
 nsswitch_conf=/etc/nsswitch.conf
 secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+secure_path_config=
 secure_path_status="disabled"
 pam_session=on
 pam_login_service=sudo
@@ -1068,9 +1070,11 @@ AC_ARG_WITH(ldap-secret-file, [AS_HELP_STRING([--with-ldap-secret-file], [path t
 test -n "$with_ldap_secret_file" && ldap_secret="$with_ldap_secret_file"
 SUDO_DEFINE_UNQUOTED(_PATH_LDAP_SECRET, "$ldap_secret", [Path to the ldap.secret file])
 
-AC_ARG_WITH(secure-path-value, [AS_HELP_STRING([--with-secure-path-value], [value of secure_path in the default sudoers file])],
+AC_ARG_WITH(secure-path-value, [AS_HELP_STRING([--with-secure-path-value], [value of secure_path in the default sudoers file, or "no" to comment out by default])],
 [case $with_secure_path_value in
-    yes|no)	AC_MSG_ERROR([must give --secure-path-value an argument.])
+    yes)	AC_MSG_ERROR([must give --with-secure-path-value an argument.])
+		;;
+    no)		secure_path_config="# "
 		;;
     *)		secure_path="$with_secure_path_value"
 		;;

--- a/plugins/sudoers/sudoers.in
+++ b/plugins/sudoers/sudoers.in
@@ -48,7 +48,7 @@ Defaults!@visudo@ env_keep += "SUDO_EDITOR EDITOR VISUAL"
 ## Use a hard-coded PATH instead of the user's to find commands.
 ## This also helps prevent poorly written scripts from running
 ## artbitrary commands under sudo.
-Defaults secure_path="@secure_path@"
+@secure_path_config@Defaults secure_path="@secure_path@"
 ##
 ## You may wish to keep some of the following environment variables
 ## when running commands via sudo.


### PR DESCRIPTION
As someone who packages `sudo` for a distribution, we received a number of reports from people surprised by the change in behaviour when we updated to sudo 1.9.16 within our stable release train. We'd like the option to preserve the previous behaviour of shipping `/etc/sudoers` with the `secure_path` option commented out for now.

This PR adds `--secure-path-value=no` to achieve that.

The interaction of the secure path configure parameters is a bit overloaded in that the single `secure_path` variable is updated by both `--with-secure-path` and `--with-secure-path-value`, the difference being whether it is just substituted into the installed `etc/sudoers` file or also built into the plugin as the default path. I didn't opt to change anything here to preserve backwards compabitility, but I wanted to mention that I found it surprising.

# Testing

## Before

#### ./configure
```
  secure path                   : no
...
% grep secure_path config.status
S["secure_path_status"]="disabled"
S["secure_path"]="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

#### ./configure --with-secure-path=no
```
  secure path                   : no
...
S["secure_path_status"]="disabled"
S["secure_path"]="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

#### ./configure --with-secure-path=/bin:/usr/bin
```
  secure path                   : /bin:/usr/bin
...
S["secure_path_status"]="set to /bin:/usr/bin"
S["secure_path"]="/bin:/usr/bin"
```

#### ./configure --with-secure-path-value=/bin:/usr/bin
```
  secure path                   : no
...
S["secure_path_status"]="disabled"
S["secure_path"]="/bin:/usr/bin"
```

## After

#### ./configure
```
  secure path                   : no
...
% grep secure_path config.status
S["secure_path_status"]="disabled"
S["secure_path_config"]=""
S["secure_path"]="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

#### ./configure --with-secure-path=no
```
  secure path                   : no
...
S["secure_path_status"]="disabled"
S["secure_path_config"]=""
S["secure_path"]="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

#### ./configure --with-secure-path=/bin:/usr/bin
```
  secure path                   : /bin:/usr/bin
...
S["secure_path_status"]="set to /bin:/usr/bin"
S["secure_path_config"]=""
S["secure_path"]="/bin:/usr/bin"
```

#### ./configure --with-secure-path-value=/bin:/usr/bin
```
  secure path                   : no
...
S["secure_path_status"]="disabled"
S["secure_path_config"]=""
S["secure_path"]="/bin:/usr/bin"
```

#### ./configure --with-secure-path-value=no
```
  secure path                   : no
...
S["secure_path_status"]="disabled"
S["secure_path_config"]="# "
S["secure_path"]="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
...
% grep secure_path etc/sudoers
# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

