### PR TITLE
Add support for multiline badpass_message

### DIFF
--- a/plugins/sudoers/auth/sudo_auth.c
+++ b/plugins/sudoers/auth/sudo_auth.c
@@ -223,6 +223,56 @@ sudo_auth_cleanup(const struct sudoers_context *ctx, struct passwd *pw,
     debug_return_int(AUTH_SUCCESS);
 }
 
+
+static void
+convert_str(char *str) {
+    char *src = str;
+    char *dst = str;
+
+    while (*src) {
+        if (src[0] == '\\') 
+	{
+	   switch (src[1])
+	   {
+		case 'a':
+		   *dst = '\a';
+		   src += 2;
+		   break;
+		case 'b':
+		   *dst = '\b';
+		   src += 2;
+		   break;
+		case 'v':
+		   *dst = '\v';
+		   src += 2;
+		   break;
+		case 'f':
+		   *dst = '\f';
+		   src += 2;
+		   break;
+		case 'n':
+		   *dst = '\n';
+		   src += 2;
+		   break;	
+		case 'e':
+		   *dst = '\033';
+		   src += 2;
+		   break;
+		default:
+		   src++;
+		   break;
+	   }
+        } 
+	else 
+	{
+            *dst = *src;
+            src++;
+        }
+        dst++;
+    }
+    *dst = '\0';
+}
+
 static void
 pass_warn(void)
 {
@@ -233,8 +283,10 @@ pass_warn(void)
     if (def_insults)
 	warning = _(INSULT);
 #endif
-    sudo_printf(SUDO_CONV_ERROR_MSG|SUDO_CONV_PREFER_TTY, "%s\n", warning);
-
+    char *second_warning = strdup(warning);
+    convert_str(second_warning);
+    sudo_printf(SUDO_CONV_ERROR_MSG|SUDO_CONV_PREFER_TTY, "%s\n", second_warning);
+    free(second_warning);
     debug_return;
 }
 


### PR DESCRIPTION
also add support for ansi code.

this is a quick hacky code that I dont expect to get merged just yet (if at all), but having the option to have badpass_message supporting multiline messages, colors and stuff.

for context, I'm a student in a french programming school and we had to set up a debian vm and, along other things, set up sudo. I was disapointed to learn that sudo dont support multiline badpass_message code (in my case, to display an ascii art), so I took it upon myself to try to add it myself with my small knowledge of C.

If people are interested in this feature, I'd love to learn the changes I'd have to make in order to actually make it good.

Have a good day !