### PR TITLE
Replace tab with space in sudoers file

### DIFF
--- a/plugins/sudoers/sudoers.in
+++ b/plugins/sudoers/sudoers.in
@@ -128,7 +128,7 @@ root ALL=(ALL:ALL) ALL
 # %wheel ALL=(ALL:ALL) NOPASSWD: ALL
 
 ## Uncomment to allow members of group sudo to execute any command
-# %sudo	ALL=(ALL:ALL) ALL
+# %sudo ALL=(ALL:ALL) ALL
 
 ## Uncomment to allow any user to run sudo if they know the password
 ## of the user they are running the command as (root by default).


### PR DESCRIPTION
A line in the sudoers file contains a tab where a space seems to be more appropriate. 

Since the tab in question is on col 8 it looks a lot like a space in many editors, but is revealed to be a tab if one were to change its position (ie. by uncommenting the line). Tabs in similar places were replaced with spaces in commit 76ce690, so this change would make the formatting of the sudoers file a bit more consistent. 