### PR TITLE
Fix getting ppid in get_process_ttyname for Linux.

### DIFF
--- a/src/ttyname.c
+++ b/src/ttyname.c
@@ -301,7 +301,7 @@ get_process_ttyname(char *name, size_t namelen)
 			    }
 			    break;
 			}
-			if (field == 3) {
+			if (field == 4) {
 			    ppid =
 				(int)sudo_strtonum(cp, INT_MIN, INT_MAX, NULL);
 			}


### PR DESCRIPTION
The ppid field in /proc/self/stat is the fourth and not the third. The latter is the process state (S, R, etc.).