### PR TITLE
Fix minor grammar errors and outdated URLs in man pages

### DIFF
--- a/docs/cvtsudoers.mdoc.in
+++ b/docs/cvtsudoers.mdoc.in
@@ -1207,7 +1207,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo.conf.mdoc.in
+++ b/docs/sudo.conf.mdoc.in
@@ -234,7 +234,7 @@ The following plugin-agnostic paths may be set in the
 file:
 .Bl -tag -width 4n
 .It askpass
-The fully qualified path to a helper program used to read the user's
+The fully-qualified path to a helper program used to read the user's
 password when no terminal is available.
 This may be the case when
 .Nm sudo
@@ -271,7 +271,7 @@ functions, for example
 .Bx ,
 macOS and Solaris.
 .It intercept
-The path to a shared library containing a wrappers for the
+The path to a shared library containing wrappers for the
 .Xr execve 2 ,
 .Xr execl 3 ,
 .Xr execle 3 ,
@@ -347,7 +347,7 @@ The default value is
 .Pa @noexec_file@ .
 .It plugin_dir
 The default directory to use when searching for plugins
-that are specified without a fully qualified path name.
+that are specified without a fully-qualified path name.
 The default value is
 .Pa @plugindir@ .
 .if \n(SL \{\
@@ -735,8 +735,8 @@ front-end configuration
 #   Path intercept /path/to/sudo_intercept.so
 #
 # Path to a shared library containing replacements for the execv()
-# and execve() library functions that perform a policy check to verify
-# the command is allowed and simply return an error if not.  This is
+# and execve() library functions, which perform a policy check to verify
+# whether the command is allowed and return an error if it is not.  This is
 # used to implement the "intercept" functionality on systems that
 # support LD_PRELOAD or its equivalent.
 #
@@ -764,7 +764,7 @@ front-end configuration
 #   Path plugin_dir /path/to/plugins
 #
 # The default directory to use when searching for plugins that are
-# specified without a fully qualified path name.
+# specified without a fully-qualified path name.
 #
 #Path plugin_dir @plugindir@
 
@@ -850,7 +850,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo.mdoc.in
+++ b/docs/sudo.mdoc.in
@@ -1676,7 +1676,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_logsrv.proto.mdoc.in
+++ b/docs/sudo_logsrv.proto.mdoc.in
@@ -819,7 +819,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_logsrv.proto.mdoc.in
+++ b/docs/sudo_logsrv.proto.mdoc.in
@@ -268,7 +268,7 @@ was previously interrupted.
 It contains the following members:
 .Bl -tag -width Ds
 .It log_id
-The the server-side name for an I/O log that was previously
+The server-side name for an I/O log that was previously
 sent to the client by the server.
 This may be a path name on the server or some other kind of server-side
 identifier.
@@ -793,7 +793,7 @@ message ServerHello {
 .Xr sudo_logsrvd @mansectsu@
 .Rs
 .%T Protocol Buffers
-.%U https://developers.google.com/protocol-buffers/
+.%U https://protobuf.dev/
 .Re
 .Sh AUTHORS
 Many people have worked on

--- a/docs/sudo_logsrvd.conf.mdoc.in
+++ b/docs/sudo_logsrvd.conf.mdoc.in
@@ -1065,7 +1065,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_logsrvd.mdoc.in
+++ b/docs/sudo_logsrvd.mdoc.in
@@ -427,7 +427,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_plugin.mdoc.in
+++ b/docs/sudo_plugin.mdoc.in
@@ -4899,7 +4899,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_plugin_python.mdoc.in
+++ b/docs/sudo_plugin_python.mdoc.in
@@ -1531,7 +1531,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudo_sendlog.mdoc.in
+++ b/docs/sudo_sendlog.mdoc.in
@@ -181,7 +181,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudoers.ldap.mdoc.in
+++ b/docs/sudoers.ldap.mdoc.in
@@ -1647,7 +1647,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudoers.ldap.mdoc.in
+++ b/docs/sudoers.ldap.mdoc.in
@@ -163,7 +163,7 @@ option (or as
 It may take command line arguments just as a normal command does.
 Unlike other commands,
 .Dq sudoedit
-is a built into
+is built into
 .Nm sudo
 itself and must be specified in without a leading path.
 .Pp
@@ -400,7 +400,7 @@ The query will match
 .Em nisNetgroupTriple
 entries with either the short or long form of the host name or
 no host name specified in the tuple.
-If the NIS domain is set, the query will match only match entries
+If the NIS domain is set, the query will only match entries
 that include the domain or for which there is no domain present.
 If the NIS domain is
 .Em not

--- a/docs/sudoers.mdoc.in
+++ b/docs/sudoers.mdoc.in
@@ -7525,7 +7525,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudoers_timestamp.mdoc.in
+++ b/docs/sudoers_timestamp.mdoc.in
@@ -293,7 +293,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/sudoreplay.mdoc.in
+++ b/docs/sudoreplay.mdoc.in
@@ -468,7 +468,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using

--- a/docs/visudo.mdoc.in
+++ b/docs/visudo.mdoc.in
@@ -516,7 +516,7 @@ sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)
 or <sudo@sudo.ws> (private).
 .Pp
-Please not report security vulnerabilities through public GitHub
+Please do not report security vulnerabilities through public GitHub
 issues, Bugzilla or mailing lists.
 Instead, report them via email to <Todd.Miller@sudo.ws>.
 You may encrypt your message with PGP if you would like, using


### PR DESCRIPTION
- Fix repeated grammar mistake: "Please not report" → "Please do not report".
- Correct phrasing around "fully qualified path" for consistency.
- Fix duplicate word: "The the" → "The" in sudo_logsrv.proto.
- Update Protocol Buffers URL to the updated canonical URL.
- Minor rewordings in sudo.conf examples to improve clarity of policy checks.