### PR TITLE
Properly check against errors against fwrite

### DIFF
--- a/lib/iolog/iolog_write.c
+++ b/lib/iolog/iolog_write.c
@@ -84,7 +84,7 @@ iolog_write(struct iolog_file *iol, const void *buf, size_t len,
 #endif
     {
 	ret = (ssize_t)fwrite(buf, 1, len, iol->fd.f);
-	if (ret <= 0) {
+	if (ret != (ssize_t)len) {
 	    ret = -1;
 	    if (errstr != NULL)
 		*errstr = strerror(errno);

--- a/plugins/python/regress/iohelpers.c
+++ b/plugins/python/regress/iohelpers.c
@@ -51,7 +51,7 @@ fwriteall(const char *file_path, const char *string)
         goto cleanup;
 
     size_t size = strlen(string);
-    if (fwrite(string, 1, size, file) < size) {
+    if (fwrite(string, 1, size, file) != size) {
         goto cleanup;
     }
 

--- a/plugins/sudoers/sudo_printf.c
+++ b/plugins/sudoers/sudo_printf.c
@@ -68,8 +68,8 @@ sudo_printf_int(int msg_type, const char * restrict fmt, ...)
 	    len = vasprintf(&buf, fmt, ap);
 	    va_end(ap);
 	}
-	if (len != -1) {
-	    if (fwrite(buf, 1, (size_t)len, ttyfp ? ttyfp : fp) == 0)
+	if (len >= 0) {
+	    if (fwrite(buf, 1, (size_t)len, ttyfp ? ttyfp : fp) != (size_t)len)
 		len = -1;
 	    if (buf != sbuf)
 		free(buf);

--- a/src/conversation.c
+++ b/src/conversation.c
@@ -120,9 +120,9 @@ sudo_conversation(int num_msgs, const struct sudo_conv_message msgs[],
 			close(ttyfd);
 		    }
 		    if (!written) {
-			if (len != 0 && fwrite(msg->msg, 1, len, fp) == 0)
+			if (len != 0 && fwrite(msg->msg, 1, len, fp) != len)
 			    goto err;
-			if (crnl != NULL && fwrite(crnl, 1, 2, fp) == 0)
+			if (crnl != NULL && fwrite(crnl, 1, 2, fp) != 2)
 			    goto err;
 		    }
 		}
@@ -218,8 +218,8 @@ sudo_conversation_printf(int msg_type, const char * restrict fmt, ...)
             len = vasprintf(&buf, fmt, ap);
             va_end(ap);
         }
-        if (len != -1) {
-            if (fwrite(buf, 1, (size_t)len, ttyfp ? ttyfp : fp) == 0)
+        if (len >= 0) {
+            if (fwrite(buf, 1, (size_t)len, ttyfp ? ttyfp : fp) != (size_t)len)
                 len = -1;
             if (buf != sbuf)
                 free(buf);


### PR DESCRIPTION
fwrite is not the same as write; you have to explicitly compare against the length to detect errors, and sometimes number of items is mistaken for length.