### PR TITLE
Clarify sudo password prompt

### DIFF
--- a/plugins/sudoers/check.c
+++ b/plugins/sudoers/check.c
@@ -301,7 +301,7 @@ display_lecture(struct sudo_conv_callback *callback)
     if (!def_pwfeedback) {
 	msg[1].msg_type = SUDO_CONV_ERROR_MSG|SUDO_CONV_PREFER_TTY;
 	msg[1].msg = _("For security reasons, the password you type will not be echoed in any form —\n"
-                   "not even as '***'. You won't see anything at all.\n\n");
+                   "not even as '***'. You won't see anything at all on your screen.\n\n");
 	msgcount++;
     }
     sudo_conv(msgcount, msg, repl, NULL);

--- a/plugins/sudoers/check.c
+++ b/plugins/sudoers/check.c
@@ -300,7 +300,8 @@ display_lecture(struct sudo_conv_callback *callback)
 	"    #3) With great power comes great responsibility.\n\n");
     if (!def_pwfeedback) {
 	msg[1].msg_type = SUDO_CONV_ERROR_MSG|SUDO_CONV_PREFER_TTY;
-	msg[1].msg = _("For security reasons, the password you type will not be visible.\n\n");
+	msg[1].msg = _("For security reasons, the password you type will not be echoed in any form —\n"
+                   "not even as '***'. You won't see anything at all.\n\n");
 	msgcount++;
     }
     sudo_conv(msgcount, msg, repl, NULL);


### PR DESCRIPTION
Update the sudo lecture message to make it explicit that the password will not be echoed in any form — not even as '*'. This improves clarity for users, emphasizing that nothing will be displayed during password input.

This change is meaningful. Every time a client asks me why their keyboard seems broken and they cannot enter a password, I have to explain clearly: their keyboard is fine—otherwise they wouldn’t be able to log in. The reason they can’t see any input is that this software, and indeed the entire Unix-like platform, is designed this way. Nothing at all is displayed on the screen—not even symbols like `****`; absolutely nothing appears. I’m tired of having to copy and paste this explanation every day, and I sincerely hope you will accept this PR. Thank you very much.

Thank you for taking the time to review my changes. I have great respect for your work, and I hope this small modification can provide a clearer experience for users. If you have any suggestions or require further adjustments, I am more than happy to cooperate. Once again, thank you for your hard work!