### PR TITLE
Enable Intel CET on x86-64 only

### DIFF
--- a/m4/hardening.m4
+++ b/m4/hardening.m4
@@ -100,13 +100,18 @@ AC_DEFUN([SUDO_CHECK_HARDENING], [
 		])
 	    fi
 
-	    # Check for control-flow transfer instrumentation (Intel CET).
-	    AX_CHECK_COMPILE_FLAG([-fcf-protection], [
-		AX_CHECK_LINK_FLAG([-fcf-protection], [
-		    AX_APPEND_FLAG([-fcf-protection], [HARDENING_CFLAGS])
-		    AX_APPEND_FLAG([-Wc,-fcf-protection], [HARDENING_LDFLAGS])
+	    # Check for control-flow transfer instrumentation (Intel CET)
+	    # on x86-64. Do not enable for 32-bit, since no 32-bit OS supports
+	    # it and the generated ENDBR32 instructions have compatibility
+	    # issues with some old i586/i686 processors (eg Geode or Vortex).
+	    if test "$host_cpu" = "x86_64"; then
+		AX_CHECK_COMPILE_FLAG([-fcf-protection], [
+		    AX_CHECK_LINK_FLAG([-fcf-protection], [
+			AX_APPEND_FLAG([-fcf-protection], [HARDENING_CFLAGS])
+			AX_APPEND_FLAG([-Wc,-fcf-protection], [HARDENING_LDFLAGS])
+		    ])
 		])
-	    ])
+	    fi
 	fi
 
 	# Linker-specific hardening flags.


### PR DESCRIPTION
Before, Intel CET was enabled for both 32-bit and 64-bit targets.

However, this made sudo incompatible with semi-i686 non-Intel and non-AMD processors, such as DM&P Vortex86 processors that are still in production, and legacy VIA/Geode processors. On those, generated ENDBR32 instructions are parsed as invalid opcodes, crashing sudo with a SIGILL:
 - https://lists.debian.org/debian-devel/2023/10/msg00118.html
 - https://bugs.gentoo.org/862201
 - https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=264497

Even for modern processors that support it, enabling it does not enhance security as no kernel in 32-bit mode supports Intel CET (neither Linux nor FreeBSD nor OpenBSD), so enabling it only increases the binary size at best and prevents entirely from running at worst.

This commit changes the compilation process to enable it only on x86-64 targets.