### PR TITLE
Use accessor for getting an ASN1_STRING's length

### DIFF
--- a/lib/iolog/hostcheck.c
+++ b/lib/iolog/hostcheck.c
@@ -208,14 +208,14 @@ matches_subject_alternative_name(const char *hostname, const char *ipaddr,
 #endif
 
 	    /* IPV4 address */
-	    if (current_name->d.iPAddress->length == 4) {
+	    if (ASN1_STRING_length(current_name->d.iPAddress) == 4) {
 		if (inet_ntop(AF_INET, san_ip, san_ip_str, INET_ADDRSTRLEN) == NULL) {
 		    ret = MalformedCertificate;
 		    break;
 		}
 #if defined(HAVE_STRUCT_IN6_ADDR)
 	    /* IPV6 address */
-	    } else if (current_name->d.iPAddress->length == 16) {
+	    } else if (ASN1_STRING_length(current_name->d.iPAddress) == 16) {
 		if (inet_ntop(AF_INET6, san_ip, san_ip_str, INET6_ADDRSTRLEN) == NULL) {
 		    ret = MalformedCertificate;
 		    break;


### PR DESCRIPTION
OpensSSL 4 has plans to [make ASN1_STRING opaque][1]. hostcheck.c's code mostly treats it as opaque, but accesses two lengths. This is API added in OpenSSL 0.9.0, so I'm not sure we need a configure check.

WolfSSL only recently const corrected ASN1_STRING_length(), so maybe there will be a need to cast away const.

[1]: https://github.com/openssl/openssl/issues/29117