### PR TITLE
Typo: AUTH_SUCESS -> AUTH_SUCCESS

### DIFF
--- a/plugins/sudoers/auth/securid5.c
+++ b/plugins/sudoers/auth/securid5.c
@@ -157,7 +157,7 @@ sudo_securid_verify(const struct sudoers_context *ctx, struct passwd *pw,
     /* Have ACE verify password */
     switch (SD_Check(*sd, pass, pw->pw_name)) {
 	case ACM_OK:
-		ret = AUTH_SUCESS;
+		ret = AUTH_SUCCESS;
 		break;
 
 	case ACE_UNDEFINED_PASSCODE:


### PR DESCRIPTION
Though I have no idea how this compiled before, or if this still does, or if it hasn't for a while if this is dead code then.