### PR TITLE
Return 0 only when realtime signals are supported, not when it isn't

### DIFF
--- a/lib/util/sig2str.c
+++ b/lib/util/sig2str.c
@@ -72,8 +72,8 @@ sudo_sig2str(int signo, char *signame)
 		(void)snprintf(signame, SIG2STR_MAX, "RTMAX-%d",
 		    (SIGRTMAX - signo));
 	    }
+        return 0;
 	}
-	return 0;
     }
 #endif
     if (signo > 0 && signo < NSIG) {


### PR DESCRIPTION
Otherwise, it would always return 0.