### PR TITLE
plugins/sudoers/lookup.c: fix NOTBEFORE to be able to deny

### DIFF
--- a/plugins/sudoers/lookup.c
+++ b/plugins/sudoers/lookup.c
@@ -126,7 +126,7 @@ sudoers_lookup_pseudo(struct sudo_nss_list *snl, struct sudoers_context *ctx,
 		    if (cs->notbefore != UNSPEC) {
 			date_match = now < cs->notbefore ? DENY : ALLOW;
 		    }
-		    if (cs->notafter != UNSPEC) {
+		    if (date_match != DENY && cs->notafter != UNSPEC) {
 			date_match = now > cs->notafter ? DENY : ALLOW;
 		    }
 		    /*
@@ -269,7 +269,7 @@ sudoers_lookup_check(struct sudo_nss *nss, struct sudoers_context *ctx,
 		if (cs->notbefore != UNSPEC) {
 		    date_match = now < cs->notbefore ? DENY : ALLOW;
 		}
-		if (cs->notafter != UNSPEC) {
+		if (date_match != DENY && cs->notafter != UNSPEC) {
 		    date_match = now > cs->notafter ? DENY : ALLOW;
 		}
 		if (date_match != DENY) {


### PR DESCRIPTION
If someone specifies both a NOTBEFORE and a NOTAFTER rule, the NOTAFTER rule always overrided the result of the NOTBEFORE. Let each of them be able to deny.

Example to demonstrate the issue: add something like this to sudoers:
        root ALL=(ALL) NOTBEFORE=20270101000000 NOTAFTER=20280101000000 NOPASSWD: /usr/bin/id
(Feel free to modify "root" to your user.)
Run "sudo id", since we are not living in year 2027, my expectation would be a deny.
However what happens is that the notbefore statement's denial will be overwritten by the notafter rule, which accepts the command run.