### PR TITLE
[race] : Move the installation of the SIGCHLD handler before fork

### DIFF
--- a/src/exec_monitor.c
+++ b/src/exec_monitor.c
@@ -616,6 +616,13 @@ exec_monitor(struct command_details *details, sigset_t *oset,
 	selinux_audit_role_change();
     }
 #endif
+    /*
+     * Create new event base and register read events for the
+     * signal pipe, error pipe, and backchannel.
+     */
+     init_exec_events_monitor(&mc, errsock[0]);
+     /* Restore signal mask now that signal handlers are setup. */
+     sigprocmask(SIG_SETMASK, oset, NULL);
 
     mc.cmnd_pid = sudo_debug_fork();
     switch (mc.cmnd_pid) {
@@ -653,15 +660,6 @@ exec_monitor(struct command_details *details, sigset_t *oset,
     cstat.type = CMD_PID;
     cstat.val = mc.cmnd_pid;
     send_status(backchannel, &cstat);
-
-    /*
-     * Create new event base and register read events for the
-     * signal pipe, error pipe, and backchannel.
-     */
-    init_exec_events_monitor(&mc, errsock[0]);
-
-    /* Restore signal mask now that signal handlers are setup. */
-    sigprocmask(SIG_SETMASK, oset, NULL);
 
     /* If any of stdin/stdout/stderr are pipes, close them in parent. */
     if (io_fds[SFD_STDIN] != io_fds[SFD_FOLLOWER])

--- a/src/exec_nopty.c
+++ b/src/exec_nopty.c
@@ -606,6 +606,10 @@ exec_nopty(struct command_details *details,
     }
 #endif
 
+    /* Allocate and set signal events and the error pipe event.*/
+    init_exec_events(&ec, evbase, errpipe[0]);
+    /* Restore signal mask now that signal handlers are setup. */
+    sigprocmask(SIG_SETMASK, &oset, NULL);
     ec.cmnd_pid = sudo_debug_fork();
     switch (ec.cmnd_pid) {
     case -1:
@@ -667,9 +671,6 @@ exec_nopty(struct command_details *details,
     if (ISSET(details->flags, CD_SET_TIMEOUT))
 	alarm(details->timeout);
 
-    /* Allocate and set signal events and the error pipe event.  */
-    init_exec_events(&ec, evbase, errpipe[0]);
-
     if (ISSET(details->flags, CD_INTERCEPT|CD_LOG_SUBCMDS)) {
 	int rc = 1;
 
@@ -691,9 +692,6 @@ exec_nopty(struct command_details *details,
 
     /* Enable any I/O log events. */
     add_io_events(&ec);
-
-    /* Restore signal mask now that signal handlers are setup. */
-    sigprocmask(SIG_SETMASK, &oset, NULL);
 
     /*
      * Non-pty event loop.

--- a/src/exec_pty.c
+++ b/src/exec_pty.c
@@ -1335,6 +1335,10 @@ exec_pty(struct command_details *details,
 	debug_return_bool(true);
     }
 
+    /* Allocate and set signal events and the backchannel event. */
+    init_exec_events(ec, evbase, sv[0]);
+    /* Restore signal mask now that signal handlers are setup. */
+    sigprocmask(SIG_SETMASK, &oset, NULL);
     ec->monitor_pid = sudo_debug_fork();
     switch (ec->monitor_pid) {
     case -1:
@@ -1408,9 +1412,6 @@ exec_pty(struct command_details *details,
     if (ISSET(details->flags, CD_SET_TIMEOUT))
 	alarm(details->timeout);
 
-    /* Allocate and set signal events and the backchannel event.  */
-    init_exec_events(ec, evbase, sv[0]);
-
     /* Create event and closure for intercept mode. */
     if (ISSET(details->flags, CD_INTERCEPT|CD_LOG_SUBCMDS)) {
 	ec->intercept = intercept_setup(intercept_sv[0], ec->evbase, details);
@@ -1421,9 +1422,6 @@ exec_pty(struct command_details *details,
     /* Reset cstat for running the command. */
     cstat->type = CMD_INVALID;
     cstat->val = 0;
-
-    /* Restore signal mask now that signal handlers are setup. */
-    sigprocmask(SIG_SETMASK, &oset, NULL);
 
     /*
      * I/O logging must be in the C locale for floating point numbers


### PR DESCRIPTION
# Race during SIGCHLD handling when PAM modules create threads - zombie child or hang. 

 

**Summary:**

sudo can miss SIGCHLD and fail to reap its child (leaving a zombie), and in some cases appear to hang waiting for the child, when a loaded PAM module creates a thread. 

This happens because sudo temporarily blocks signals, including SIGCHLD, using [`sigprocmask()`](https://github.com/sudo-project/sudo/blob/fc9369cb442c8c5f6612d1831294569f1db75028/src/exec_nopty.c#L580)  in the calling thread. It then calls [`fork()`](https://github.com/sudo-project/sudo/blob/fc9369cb442c8c5f6612d1831294569f1db75028/src/exec_nopty.c#L603) and installs or restores the SIGCHLD handler only [afterward](https://github.com/sudo-project/sudo/blob/fc9369cb442c8c5f6612d1831294569f1db75028/src/exec_nopty.c#L668).

If the child exits before the handler is installed, and PAM has created another thread where SIGCHLD is not blocked, the kernel may deliver the signal to that other thread. The thread that later waits for the child never receives it.

As a result, sudo misses the expected wake‑up path.

Moving the installation of SIGCHLD handler earlier (before `fork()`) fixes the issue in my testing. 

 ---

**Affected area:** 

exec_nopty.c exec_pty.c and exec_monitor.c  

 

**Expected behavior:**

sudo should reliably reap its child and never hang or leave a zombie, regardless of whether PAM modules create threads. 

 

**Actual behavior:** 

Under the below conditions, sudo can: 

- Leave a zombie child process, and/or 

- Hang indefinitely waiting for the child completion path (depending on timing and wait logic) 

---
## Root cause analysis (signal/thread interaction)

The problematic sequence: 

1. sudo invokes PAM (some PAM modules create threads). 

2. sudo blocks signals via `sigprocmask()` (Linux: affects current thread only, other threads keep their existing masks). 

3. sudo calls `fork()`. 

4. In the parent, sudo installs/restores its SIGCHLD handler. 

5. Parent unblocks signals. 

 

If the child exits quickly between (3) and (4), the kernel generates SIGCHLD. In a single-threaded process, it becomes pending for the process/thread as expected, and is indeed handled later. But if PAM created any additional thread, and that thread does not have the SIGCHLD blocked, the kernel can deliver SIGCHLD to that thread. That thread is not a part of sudo’s expected control flow for reaping/waiting, so the parent thread may never observe the signal it expects, causing the zombie/hang. 

 

_NOTE: POSIX leaves `sigprocmask()` behavior unspecified in multi-threaded processes, Linux effectively treats `sigprocmask()` as thread-scoped (like `pthread_sigmask()` ), which is consistent with the above failure mode._
 

**Conditions required:** 

- Linux. 

- Sudo loads a PAM module. 

- That PAM module has created at least one thread. 

- The sudo child exits fast enough to race with parent-side handler restoration. 

## Real-world relevance

Although most traditional Linux-PAM modules are synchronous and single-threaded, the PAM API does not forbid thread creation, and in practice PAM modules written in modern languages may introduce threads as a part of their runtime initialization. In particular, any PAM module written in Go will create multiple OS threads as a part of Go runtime initialization, even if the module code itself does not explicitly create goroutines. For instance, third-party PAM modules such as `pam_ussh` create multiple OS threads as part of the Go runtime initialization.

As a result, the assumption that `sudo` remains single-threaded across PAM invocation is invalid. The minimal C PAM module included below intentionally removes all language-runtime complexity and demonstrates that any PAM module that creates a single background thread can trigger this SIGCHLD race. This shows that the issue is not Go-specific, but a general interaction bug between PAM, sudo, signals, and multi-threaded processes.

	
## Real-world strace-ing
The following strace outputs were collected using
```
> strace -o /tmp/thread-sudo-strace-output -ff -tt -e trace=clone,clone3,rt_sigprocmask,rt_sigaction,wait4 sudo /bin/true	
```
This is the parent thread(TID 2410273) identified using `wait4()`
```
> grep -l "wait4(" /tmp/thread-sudo-strace-output.*

/tmp/thread-sudo-strace-output.2410273
```
This trace shows that sudo becomes multi-threaded prior to fork due to PAM module/runtime initialization
```
>  grep -H "clone3(" /tmp/thread-sudo-strace-output.*

/tmp/thread-sudo-strace-output.2410273:10:53:06.642565 clone3({flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, child_tid=0x739d447ff990, parent_tid=0x739d447ff990, exit_signal=0, stack=0x739d43fff000, stack_size=0x7ffe80, tls=0x739d447ff6c0} => {parent_tid=[2410274]}, 88) = 2410274
/tmp/thread-sudo-strace-output.2410274:10:53:06.646725 clone3({flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, child_tid=0x739d415ff990, parent_tid=0x739d415ff990, exit_signal=0, stack=0x739d40dff000, stack_size=0x7ffe80, tls=0x739d415ff6c0} => {parent_tid=[2410275]}, 88) = 2410275
/tmp/thread-sudo-strace-output.2410274:10:53:06.647775 clone3({flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, child_tid=0x739d40dfe990, parent_tid=0x739d40dfe990, exit_signal=0, stack=0x739d405fe000, stack_size=0x7ffe80, tls=0x739d40dfe6c0} => {parent_tid=[2410276]}, 88) = 2410276
...
```
In the main sudo thread, sudo blocks signals including SIGCHLD, using `rt_sigprocmask()`. These affect only the calling thread.
```
> grep "rt_sigprocmask" /tmp/thread-sudo-strace-output.2410273

...
10:53:06.642528 rt_sigprocmask(SIG_BLOCK, ~[], [], 8) = 0
...
10:53:06.675802 rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
```
In the other threads that're created before the fork, the signal mask is restored to an empty set, i.e., the SIGCHLD is unblocked.
```
> grep "rt_sigprocmask" /tmp/thread-sudo-strace-output.2410276
...
10:53:06.651377 rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0

> grep "rt_sigprocmask" /tmp/thread-sudo-strace-output.2410275
...
10:53:06.647189 rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0

> grep "rt_sigprocmask" /tmp/thread-sudo-strace-output.2410274
...
10:53:06.651945 rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
```
	
The main thread then forks the child and attempts to also reap it:
```
>  grep -E "clone\\(|clone3\\(|wait4" /tmp/thread-sudo-strace-output.2410273
...
10:53:06.675871 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x739d45e7f390) = 2410282
10:53:06.681803 wait4(-1, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], WNOHANG|WSTOPPED|__WALL, NULL) = 2410282
```
In this particular run, the child happened to be reaped successfully, but the trace still demonstrates that:
- sudo is multi-threaded before `fork()`
- SIGCHLD is blocked only in the main thread
- at least one other thread has SIGCHLD unblocked during the race window.
This establishes a race condition, if the child exits while SIGCHLD is unblocked in a non-control thread, the kernel may deliver the SIGCHLD to that thread instead of the main sudo thread. In that case, sudo's expected child-reaping path may not be awakened, leading to a missed SIGCHLD, a zombie child or an apparent hang.	
--- 

## Reproducers: 

To reproduce this, we will need a PAM module. This PAM module involves minimal thread creation + thread blocks indefinitely in a syscall that can be restarted. 

 
```c
#include <unistd.h>
#include <pthread.h>
#include <linux/futex.h>
#include <sys/syscall.h>

#include <stdio.h>
#include <fcntl.h>

#include <security/pam_modules.h>

void* thread_wait(void* arg) {
    /* Example using FUTEX_WAIT. The thread exists and is schedulable to receive signals. */
    int futex = 0;
    syscall(SYS_futex, &futex, FUTEX_WAIT, 0, NULL, NULL, 0);
    return NULL;
}

PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv) {
    pthread_t thread;
    pthread_create(&thread, NULL, thread_wait, NULL);
    return PAM_SUCCESS;
}

PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv) {
    return PAM_SUCCESS;
}

```
**Build:** 
```
> gcc -fPIC -shared -o /tmp/sudo_sig.so /tmp/sudo_sig.c -lpthread 
```
 

Configure PAM, add this to /etc/pam.d/sudo: 
```
session required /tmp/sudo_sig.so 
```

**Deterministic via a forced delay:** 

1. Insert a delay in the parent path in exec_nopty to widen the window between `fork()` and handler restoration: 

	 
```
usleep(100000) ; 
```

Place it right before the call to `fill_exec_closure_nopty(...)`. This makes the issue reproduce nearly every time the PAM module below and a fast command like /bin/true. 

 

2.  Run a fast command that exits quickly: 
```
> sudo /bin/true 
```
 

Observed results include a defunct child: 
```
> sudo /bin/true & 

> ps --ppid $! -o pid,ppid,state,cmd 

# Shows: Z [true] <defunct> 
```
 

**Non-deterministic, no source modification:** 

1. Run a fast command in a tight loop for long enough, eventually the race triggers: 
```bash
#!/bin/bash 
while true; do 
    sudo /bin/true 
done 
```
2. After some time : 
```
> ps aux | grep defunct 

# ... [true] <defunct> 
```
And confirm its parent is a sudo /bin/true instance from the loop 

 

**Impact:** 

- Zombie accumulation in long-running workflows that call sudo repeatedly. 

- Potential indefinite hang. 

With my changes, moving the handler restoration in `exec_monitor.c`, `exec_pty.c` and `exec_nopty.c`, I was unable to reproduce this. 

NOTE: The strace output shared was with `sudo-v1.9.15p5`.