### PR TITLE
cvtsudoers_make_gritem: fix off-by-one in gr_mem allocation

### DIFF
--- a/plugins/sudoers/cvtsudoers_pwutil.c
+++ b/plugins/sudoers/cvtsudoers_pwutil.c
@@ -230,6 +230,7 @@ cvtsudoers_make_gritem(gid_t gid, const char *name)
 	    total += strlen(s->str) + 1;
 	    nmem++;
 	}
+	nmem++;	/* include space for the NULL terminator */
 	total += sizeof(char *) * nmem;
     }
     if (name != NULL)


### PR DESCRIPTION
cvtsudoers_make_gritem() allocates space for the gr_mem pointer array using sizeof(char *) * nmem, where nmem is the number of filter users. However, gr_mem is a conventional NULL-terminated array, and the NULL terminator slot was never included in the allocation.  When newgr->gr_mem[nmem] is subsequently written with NULL, it lands one pointer past the end of the reserved pointer array, overwriting the first bytes of the adjacent member-string data.  With few members and short names the write can extend past the end of the allocation entirely, corrupting adjacent heap memory.

Fix by incrementing nmem before computing the pointer-array size, so that the NULL terminator slot is included in the allocation.  This mirrors the pattern used in PREFIX(make_gritem) in pwutil_impl.c.