### PR TITLE
Do not use the path variable in switch_dir() in case of error

### DIFF
--- a/plugins/sudoers/toke.l
+++ b/plugins/sudoers/toke.l
@@ -1033,7 +1033,7 @@ switch_dir(struct include_stack *stack, char *dirpath, int verbose)
     debug_decl(switch_dir, SUDOERS_DEBUG_PARSER);
 
     count = read_dir_files(dirpath, &paths, verbose);
-    if (count > 0) {
+    if (count > 0 && count != SIZE_MAX) {
 	/* Sort the list as an array in reverse order. */
 	qsort(paths, count, sizeof(*paths), pl_compare);
 


### PR DESCRIPTION
In the function switch_dir() the path variable is initialized to NULL.

The read_dir_files() is invoked to assign it a value. When this function finishes with an error (goes to oom or bad), no value is assigned to the parameter *pathsp and SIZE_MAX is returned. SIZE_MAX is the equivalent of -1, but is unsigned, so it is a very high positive value.

Function switch_dir() will check that the result is greater than 0, which will be in case of error because the variable count and the result value are both unsigned, although the equivalent of -1. So we need to check for this particular value explicitly.

Resolves: https://github.com/sudo-project/sudo/issues/533