### PR TITLE
[sudo-1.9] Backport CVE-2026-35535: exec_mailer drop group as well as uid

### DIFF
--- a/include/sudo_eventlog.h
+++ b/include/sudo_eventlog.h
@@ -80,6 +80,7 @@ struct eventlog_config {
     int syslog_rejectpri;
     int syslog_alertpri;
     uid_t mailuid;
+    gid_t mailgid;
     bool omit_hostname;
     const char *logpath;
     const char *time_fmt;
@@ -151,7 +152,7 @@ void eventlog_set_syslog_rejectpri(int pri);
 void eventlog_set_syslog_alertpri(int pri);
 void eventlog_set_syslog_maxlen(size_t len);
 void eventlog_set_file_maxlen(size_t len);
-void eventlog_set_mailuid(uid_t uid);
+void eventlog_set_mailuser(uid_t uid, gid_t gid);
 void eventlog_set_omit_hostname(bool omit_hostname);
 void eventlog_set_logpath(const char *path);
 void eventlog_set_time_fmt(const char *fmt);

--- a/lib/eventlog/eventlog.c
+++ b/lib/eventlog/eventlog.c
@@ -304,15 +304,13 @@ exec_mailer(int pipein)
 	syslog(LOG_ERR, _("unable to dup stdin: %m")); // -V618
 	sudo_debug_printf(SUDO_DEBUG_ERROR,
 	    "unable to dup stdin: %s", strerror(errno));
-	sudo_debug_exit(__func__, __FILE__, __LINE__, sudo_debug_subsys);
-	_exit(127);
+	goto bad;
     }
 
     /* Build up an argv based on the mailer path and flags */
     if ((mflags = strdup(evl_conf->mailerflags)) == NULL) {
 	syslog(LOG_ERR, _("unable to allocate memory")); // -V618
-	sudo_debug_exit(__func__, __FILE__, __LINE__, sudo_debug_subsys);
-	_exit(127);
+	goto bad;
     }
     argv[0] = sudo_basename(mpath);
 
@@ -331,11 +329,23 @@ exec_mailer(int pipein)
     if (setuid(ROOT_UID) != 0) {
 	sudo_debug_printf(SUDO_DEBUG_ERROR, "unable to change uid to %u",
 	    ROOT_UID);
+	goto bad;
+    }
+    if (setgid(evl_conf->mailgid) != 0) {
+	sudo_debug_printf(SUDO_DEBUG_ERROR, "unable to change gid to %u",
+	    (unsigned int)evl_conf->mailgid);
+	goto bad;
+    }
+    if (setgroups(1, &evl_conf->mailgid) != 0) {
+	sudo_debug_printf(SUDO_DEBUG_ERROR, "unable to set groups to %u",
+	    (unsigned int)evl_conf->mailgid);
+	goto bad;
     }
     if (evl_conf->mailuid != ROOT_UID) {
 	if (setuid(evl_conf->mailuid) != 0) {
 	    sudo_debug_printf(SUDO_DEBUG_ERROR, "unable to change uid to %u",
 		(unsigned int)evl_conf->mailuid);
+	    goto bad;
 	}
     }
     sudo_debug_exit(__func__, __FILE__, __LINE__, sudo_debug_subsys);
@@ -346,6 +356,9 @@ exec_mailer(int pipein)
     syslog(LOG_ERR, _("unable to execute %s: %m"), mpath); // -V618
     sudo_debug_printf(SUDO_DEBUG_ERROR, "unable to execute %s: %s",
 	mpath, strerror(errno));
+    _exit(127);
+bad:
+    sudo_debug_exit(__func__, __FILE__, __LINE__, sudo_debug_subsys);
     _exit(127);
 }
 

--- a/lib/eventlog/eventlog_conf.c
+++ b/lib/eventlog/eventlog_conf.c
@@ -70,6 +70,7 @@ static struct eventlog_config evl_conf = {
     MAXSYSLOGLEN,		/* syslog_maxlen */
     0,				/* file_maxlen */
     ROOT_UID,			/* mailuid */
+    ROOT_GID,			/* mailgid */
     false,			/* omit_hostname */
     _PATH_SUDO_LOGFILE,		/* logpath */
     "%h %e %T",			/* time_fmt */
@@ -151,9 +152,10 @@ eventlog_set_file_maxlen(size_t len)
 }
 
 void
-eventlog_set_mailuid(uid_t uid)
+eventlog_set_mailuser(uid_t uid, gid_t gid)
 {
     evl_conf.mailuid = uid;
+    evl_conf.mailgid = gid;
 }
 
 void

--- a/plugins/sudoers/logging.c
+++ b/plugins/sudoers/logging.c
@@ -1157,7 +1157,7 @@ init_eventlog_config(void)
     eventlog_set_syslog_alertpri(def_syslog_badpri);
     eventlog_set_syslog_maxlen(def_syslog_maxlen);
     eventlog_set_file_maxlen(def_loglinelen);
-    eventlog_set_mailuid(ROOT_UID);
+    eventlog_set_mailuser(ROOT_UID, ROOT_GID);
     eventlog_set_omit_hostname(!def_log_host);
     eventlog_set_logpath(def_logfile);
     eventlog_set_time_fmt(def_log_year ? "%h %e %T %Y" : "%h %e %T");

--- a/plugins/sudoers/policy.c
+++ b/plugins/sudoers/policy.c
@@ -639,7 +639,7 @@ sudoers_policy_deserialize_info(struct sudoers_context *ctx, void *v,
     }
 
 #ifdef NO_ROOT_MAILER
-    eventlog_set_mailuid(ctx->user.uid);
+    eventlog_set_mailuser(ctx->user.uid, ctx->user.gid);
 #endif
 
     /* Dump settings and user info (XXX - plugin args) */


### PR DESCRIPTION
backport of `3e474c2f2014` to `sudo-1.9` for CVE-2026-35535.

the upstream fix tightens privilege drop in `exec_mailer` — sets the group as well as uid (and treats setuid/setgid/setgroups failures as fatal). 5 files touched, mostly `lib/eventlog/eventlog.c` and `include/sudo_eventlog.h`.

upstream: https://github.com/sudo-project/sudo/commit/3e474c2f2014
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-35535

cherry-picked with `-x`, applied cleanly on `sudo-1.9`. haven't run the full regression suite locally — change is contained to the eventlog/mailer path.