### PR TITLE
tgetpass: Honor WAYLAND_DISPLAY and WAYLAND_SOCKET

### DIFF
--- a/src/tgetpass.c
+++ b/src/tgetpass.c
@@ -131,7 +131,10 @@ restart:
 	/* If no tty present and we need to disable echo, try askpass. */
 	ttyfd = open(_PATH_TTY, O_RDWR);
 	if (ttyfd == -1 && !ISSET(flags, TGP_ECHO|TGP_NOECHO_TRY)) {
-	    if (askpass == NULL || getenv_unhooked("DISPLAY") == NULL) {
+	    if (askpass == NULL ||
+	        (getenv_unhooked("DISPLAY") == NULL &&
+	         getenv_unhooked("WAYLAND_DISPLAY") == NULL &&
+	         getenv_unhooked("WAYLAND_SOCKET") == NULL)) {
 		if (getenv_unhooked("SSH_CONNECTION") != NULL && getenv_unhooked("SSH_TTY") == NULL) {
 		    sudo_warnx("%s",
 			U_("a terminal is required to read the password; either use ssh's -t option or configure an askpass helper"));


### PR DESCRIPTION
In case no DISPLAY is set, askpass may still properly run in a wayland compositor, so also rely on the related env variables.