### PR TITLE
docs: use .Lk macro for GitHub issues URL

### DIFF
--- a/docs/sudo.conf.mdoc.in
+++ b/docs/sudo.conf.mdoc.in
@@ -844,7 +844,8 @@ If you believe you have found a bug in
 .Nm ,
 you can either file a bug report in the sudo bug database,
 https://bugzilla.sudo.ws/, or open an issue at
-https://github.com/sudo-project/sudo/issues.
+.Lk https://github.com/sudo-project/sudo/issues
+.
 If you would prefer to use email, messages may be sent to the
 sudo-workers mailing list,
 https://www.sudo.ws/mailman/listinfo/sudo-workers (public)


### PR DESCRIPTION
Use the .Lk macro for the GitHub issues URL to prevent trailing punctuation from being included in the rendered link.

Source:
https://github.com/sudo-project/sudo/issues.

Expected:
The URL should link to:
https://github.com/sudo-project/sudo/issues

Actual:
The hyperlink includes the trailing "." character.

<img width="1919" height="901" alt="481fa59a-16ee-4f79-84d9-ca0a74812744" src="https://github.com/user-attachments/assets/07948269-4eb2-452f-9076-a838d97f373b" />
