### PR TITLE
mkdep.pl: Prevent infinite recursion when looking for includes

### DIFF
--- a/scripts/mkdep.pl
+++ b/scripts/mkdep.pl
@@ -281,6 +281,10 @@ sub find_depends {
 	my ($hdr, $hdr_path) = find_header($src, $1);
 	if (defined($hdr)) {
 	    $headers{$hdr} = 1;
+	    if ($src eq $hdr_path) {
+		next
+	    }
+
 	    # Look for other includes in the .h file
 	    foreach (find_depends($hdr_path)) {
 		$headers{$_} = 1;


### PR DESCRIPTION
Prevent infinite recursion when an include statement includes the current file. Normally, this would never be an issue, but this addresses the case where the include statement is contained within a multi-line comment.